### PR TITLE
Fix `map_tracks` with untracked cell number change

### DIFF
--- a/tobac/plotting.py
+++ b/tobac/plotting.py
@@ -1730,8 +1730,10 @@ def plot_mask_cell_track_static_timeseries(
         plt.clf()
 
 
-def map_tracks(track, axis_extent=None, figsize=None, axes=None, untracked_cell_value = -1):
-    '''Maps the tracks of all tracked cells
+def map_tracks(
+    track, axis_extent=None, figsize=None, axes=None, untracked_cell_value=-1
+):
+    """Maps the tracks of all tracked cells
 
     Parameters
     ----------
@@ -1745,20 +1747,25 @@ def map_tracks(track, axis_extent=None, figsize=None, axes=None, untracked_cell_
         Axes to plot the tracks onto
     untracked_cell_value: int or np.nan
         Untracked cell value from tobac.
-    
+
     Returns
     -------
-    Returns `axes` with the tracks plotted onto it. 
+    Returns `axes` with the tracks plotted onto it.
 
     Raises
     ------
     Raises a `ValueError` if `axes` is not passed in.
 
-    '''
+    """
     if figsize is not None:
-        warnings.warn('figsize is depreciated as this function does not create its own figure.', DeprecationWarning)
+        warnings.warn(
+            "figsize is depreciated as this function does not create its own figure.",
+            DeprecationWarning,
+        )
     if axes is None:
-        raise ValueError('axes needed to plot tracks onto. Pass in an axis to axes to resolve this error.')
+        raise ValueError(
+            "axes needed to plot tracks onto. Pass in an axis to axes to resolve this error."
+        )
     for cell in track["cell"].dropna().unique():
         if cell == untracked_cell_value:
             continue

--- a/tobac/plotting.py
+++ b/tobac/plotting.py
@@ -1730,8 +1730,38 @@ def plot_mask_cell_track_static_timeseries(
         plt.clf()
 
 
-def map_tracks(track, axis_extent=None, figsize=(10, 10), axes=None):
+def map_tracks(track, axis_extent=None, figsize=None, axes=None, untracked_cell_value = -1):
+    '''Maps the tracks of all tracked cells
+
+    Parameters
+    ----------
+    track: pandas dataframe
+        Tracks from tobac
+    axis_extent: array-like, length 4
+        Extent of the map, as required by `cartopy`
+    figsize: depreciated
+        Depreciated parameter
+    axes: Matplotlib axes or geoaxes from cartopy
+        Axes to plot the tracks onto
+    untracked_cell_value: int or np.nan
+        Untracked cell value from tobac.
+    
+    Returns
+    -------
+    Returns `axes` with the tracks plotted onto it. 
+
+    Raises
+    ------
+    Raises a `ValueError` if `axes` is not passed in.
+
+    '''
+    if figsize is not None:
+        warnings.warn('figsize is depreciated as this function does not create its own figure.', DeprecationWarning)
+    if axes is None:
+        raise ValueError('axes needed to plot tracks onto. Pass in an axis to axes to resolve this error.')
     for cell in track["cell"].dropna().unique():
+        if cell == untracked_cell_value:
+            continue
         track_i = track[track["cell"] == cell]
         axes.plot(track_i["longitude"], track_i["latitude"], "-")
         if axis_extent:


### PR DESCRIPTION
This resolves #128 and #121, related to the fact that `map_tracks` in the plotting module depends on the untracked cells being labeled as `np.nan`.

Given the number of bug reports related to this, I recommend that we release this as a hotfix 1.3.1 release. 