### PR TITLE
Added depreciation warnings to two segmentation functions

### DIFF
--- a/tobac/segmentation.py
+++ b/tobac/segmentation.py
@@ -310,10 +310,33 @@ def segmentation(
 
 
 def watershedding_3D(track, field_in, **kwargs):
+    warnings.simplefilter(
+        "always", DeprecationWarning
+    )  # turn off filter; this is an easy switch for users.
+    warnings.warn(
+        "Warning: using deprecated function `watershedding_3D`. Switch to `segmentation` instead."
+        " The arguments and output of `segmentation` is the same, so it is an easy switch."
+        " This function will be removed in v1.5.0.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    warnings.simplefilter("default", DeprecationWarning)  # reset filter
+
     kwargs.pop("method", None)
     return segmentation_3D(track, field_in, method="watershed", **kwargs)
 
 
 def watershedding_2D(track, field_in, **kwargs):
+    warnings.simplefilter(
+        "always", DeprecationWarning
+    )  # turn off filter; this is an easy switch for users.
+    warnings.warn(
+        "Warning: using deprecated function `watershedding_2D`. Switch to `segmentation` instead."
+        " The arguments and output of `segmentation` is the same, so it is an easy switch."
+        " This function will be removed in v1.5.0.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
     kwargs.pop("method", None)
     return segmentation_2D(track, field_in, method="watershed", **kwargs)

--- a/tobac/segmentation.py
+++ b/tobac/segmentation.py
@@ -1,4 +1,5 @@
 import logging
+from multiprocessing.sharedctypes import Value
 import warnings
 
 
@@ -323,7 +324,9 @@ def watershedding_3D(track, field_in, **kwargs):
     warnings.simplefilter("default", DeprecationWarning)  # reset filter
 
     kwargs.pop("method", None)
-    return segmentation_3D(track, field_in, method="watershed", **kwargs)
+    if 'dxy' not in kwargs:
+        raise ValueError("Need grid spacing `dxy`.")
+    return segmentation(track, field_in, dxy=kwargs.get('dxy'), method="watershed", **kwargs)
 
 
 def watershedding_2D(track, field_in, **kwargs):
@@ -339,4 +342,6 @@ def watershedding_2D(track, field_in, **kwargs):
     )
 
     kwargs.pop("method", None)
-    return segmentation_2D(track, field_in, method="watershed", **kwargs)
+    if 'dxy' not in kwargs:
+        raise ValueError("Need grid spacing `dxy`.")
+    return segmentation(track, field_in, dxy=kwargs.get('dxy'), method="watershed", **kwargs)

--- a/tobac/segmentation.py
+++ b/tobac/segmentation.py
@@ -324,9 +324,11 @@ def watershedding_3D(track, field_in, **kwargs):
     warnings.simplefilter("default", DeprecationWarning)  # reset filter
 
     kwargs.pop("method", None)
-    if 'dxy' not in kwargs:
+    if "dxy" not in kwargs:
         raise ValueError("Need grid spacing `dxy`.")
-    return segmentation(track, field_in, dxy=kwargs.get('dxy'), method="watershed", **kwargs)
+    return segmentation(
+        track, field_in, dxy=kwargs.get("dxy"), method="watershed", **kwargs
+    )
 
 
 def watershedding_2D(track, field_in, **kwargs):
@@ -342,6 +344,8 @@ def watershedding_2D(track, field_in, **kwargs):
     )
 
     kwargs.pop("method", None)
-    if 'dxy' not in kwargs:
+    if "dxy" not in kwargs:
         raise ValueError("Need grid spacing `dxy`.")
-    return segmentation(track, field_in, dxy=kwargs.get('dxy'), method="watershed", **kwargs)
+    return segmentation(
+        track, field_in, dxy=kwargs.get("dxy"), method="watershed", **kwargs
+    )

--- a/tobac/segmentation.py
+++ b/tobac/segmentation.py
@@ -326,9 +326,9 @@ def watershedding_3D(track, field_in, **kwargs):
     kwargs.pop("method", None)
     if "dxy" not in kwargs:
         raise ValueError("Need grid spacing `dxy`.")
-    return segmentation(
-        track, field_in, dxy=kwargs.get("dxy"), method="watershed", **kwargs
-    )
+    dxy = kwargs.get("dxy")
+    kwargs.pop("dxy", None)
+    return segmentation(track, field_in, dxy=dxy, method="watershed", **kwargs)
 
 
 def watershedding_2D(track, field_in, **kwargs):
@@ -346,6 +346,6 @@ def watershedding_2D(track, field_in, **kwargs):
     kwargs.pop("method", None)
     if "dxy" not in kwargs:
         raise ValueError("Need grid spacing `dxy`.")
-    return segmentation(
-        track, field_in, dxy=kwargs.get("dxy"), method="watershed", **kwargs
-    )
+    dxy = kwargs.get("dxy")
+    kwargs.pop("dxy", None)
+    return segmentation(track, field_in, dxy=dxy, method="watershed", **kwargs)

--- a/tobac/segmentation.py
+++ b/tobac/segmentation.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 
 def segmentation_3D(
@@ -11,6 +12,17 @@ def segmentation_3D(
     method="watershed",
     max_distance=None,
 ):
+    warnings.simplefilter(
+        "always", DeprecationWarning
+    )  # turn off filter; this is an easy switch for users.
+    warnings.warn(
+        "Warning: using deprecated function `segmentation_3D`. Switch to `segmentation` instead."
+        " The arguments and output of `segmentation` is the same, so it is an easy switch."
+        " This function will be removed in v1.5.0.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    warnings.simplefilter("default", DeprecationWarning)  # reset filter
     return segmentation(
         features,
         field,
@@ -33,6 +45,18 @@ def segmentation_2D(
     method="watershed",
     max_distance=None,
 ):
+    warnings.simplefilter(
+        "always", DeprecationWarning
+    )  # turn off filter; this is an easy switch for users.
+    warnings.warn(
+        "Warning: using deprecated function `segmentation_2D`. Switch to `segmentation` instead."
+        " The arguments and output of `segmentation` is the same, so it is an easy switch."
+        " This function will be removed in v1.5.0.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    warnings.simplefilter("default", DeprecationWarning)  # reset filter
+
     return segmentation(
         features,
         field,


### PR DESCRIPTION
This resolves #145 and calls for the `segmentation_2D` and `segmentation_3D` to be removed by v1.5.0. 

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [ ] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

