### PR TITLE
Fixing `weighted_abs` feature position

### DIFF
--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -90,7 +90,7 @@ def feature_position(
 
     elif position_threshold == "weighted_abs":
         # get position as centre of identified region, weighted by absolute values if the field:
-        weights = abs(track_data[region_small])
+        weights = abs(track_data_region[region_small])
         if sum(weights) == 0:
             weights = None
         hdim1_index = np.average(hdim1_indices, weights=weights)

--- a/tobac/tests/test_feature_detection.py
+++ b/tobac/tests/test_feature_detection.py
@@ -1,4 +1,3 @@
-import tobac.testing
 import tobac.testing as tbtest
 import tobac.feature_detection as feat_detect
 import pytest
@@ -9,7 +8,6 @@ def test_feature_detection_multithreshold_timestep():
     Tests ```tobac.feature_detection.feature_detection_multithreshold_timestep
     """
     import numpy as np
-    from tobac import testing
     from tobac import feature_detection
 
     # start by building a simple dataset with a single feature and seeing
@@ -27,7 +25,7 @@ def test_feature_detection_multithreshold_timestep():
     test_min_num = 2
 
     test_data = np.zeros(test_dset_size)
-    test_data = testing.make_feature_blob(
+    test_data = tbtest.make_feature_blob(
         test_data,
         test_hdim_1_pt,
         test_hdim_2_pt,
@@ -35,7 +33,7 @@ def test_feature_detection_multithreshold_timestep():
         h2_size=test_hdim_2_sz,
         amplitude=test_amp,
     )
-    test_data_iris = testing.make_dataset_from_arr(test_data, data_type="iris")
+    test_data_iris = tbtest.make_dataset_from_arr(test_data, data_type="iris")
     fd_output = feature_detection.feature_detection_multithreshold_timestep(
         test_data_iris, 0, threshold=test_threshs, n_min_threshold=test_min_num
     )

--- a/tobac/tests/test_feature_detection.py
+++ b/tobac/tests/test_feature_detection.py
@@ -1,4 +1,5 @@
 import tobac.testing
+import tobac.testing as tbtest
 import tobac.feature_detection as feat_detect
 import pytest
 
@@ -44,3 +45,31 @@ def test_feature_detection_multithreshold_timestep():
     # Make sure that the location of the feature is correct
     assert fd_output.iloc[0]["hdim_1"] == pytest.approx(test_hdim_1_pt)
     assert fd_output.iloc[0]["hdim_2"] == pytest.approx(test_hdim_2_pt)
+
+@pytest.mark.parametrize(
+    "position_threshold",
+    [("center"), ("extreme"), ("weighted_diff"), ("weighted_abs")]
+)
+def test_feature_detection_position(position_threshold):
+    '''
+    Tests to make sure that all feature detection position_thresholds work. 
+    '''
+    import numpy as np
+    test_dset_size = (50, 50)
+
+    test_data = np.zeros(test_dset_size)
+
+    test_data[0:5,0:5] = 3
+    test_threshs = [
+        1.5,
+    ]
+    test_min_num = 2
+
+    test_data_iris = tbtest.make_dataset_from_arr(test_data, data_type="iris")
+
+    fd_output = feat_detect.feature_detection_multithreshold_timestep(
+        test_data_iris, 0, threshold=test_threshs, n_min_threshold=test_min_num, position_threshold = position_threshold
+    )
+
+
+    pass

--- a/tobac/tests/test_feature_detection.py
+++ b/tobac/tests/test_feature_detection.py
@@ -46,20 +46,21 @@ def test_feature_detection_multithreshold_timestep():
     assert fd_output.iloc[0]["hdim_1"] == pytest.approx(test_hdim_1_pt)
     assert fd_output.iloc[0]["hdim_2"] == pytest.approx(test_hdim_2_pt)
 
+
 @pytest.mark.parametrize(
-    "position_threshold",
-    [("center"), ("extreme"), ("weighted_diff"), ("weighted_abs")]
+    "position_threshold", [("center"), ("extreme"), ("weighted_diff"), ("weighted_abs")]
 )
 def test_feature_detection_position(position_threshold):
-    '''
-    Tests to make sure that all feature detection position_thresholds work. 
-    '''
+    """
+    Tests to make sure that all feature detection position_thresholds work.
+    """
     import numpy as np
+
     test_dset_size = (50, 50)
 
     test_data = np.zeros(test_dset_size)
 
-    test_data[0:5,0:5] = 3
+    test_data[0:5, 0:5] = 3
     test_threshs = [
         1.5,
     ]
@@ -68,8 +69,11 @@ def test_feature_detection_position(position_threshold):
     test_data_iris = tbtest.make_dataset_from_arr(test_data, data_type="iris")
 
     fd_output = feat_detect.feature_detection_multithreshold_timestep(
-        test_data_iris, 0, threshold=test_threshs, n_min_threshold=test_min_num, position_threshold = position_threshold
+        test_data_iris,
+        0,
+        threshold=test_threshs,
+        n_min_threshold=test_min_num,
+        position_threshold=position_threshold,
     )
-
 
     pass


### PR DESCRIPTION
This PR addresses #148 and resolves a bug when using `weighted_abs` feature position in 1.3.x. Given the hotfix nature of this, I'm suggesting we stage it for a relatively rapidly released 1.3.2. 

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [ ] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [x] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

