### PR TITLE
Use a specified version of black in workflow

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -9,6 +9,6 @@ jobs:
         with:
           python-version: '3.8'
       - run: pip install .
-      - run: pip install black
+      - run: pip install black==22.6.0 
       - run: black tobac --check
       

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Please create a new issue on [GitHub](https://github.com/climate-processes/tobac
 * Before you start a pull request, please make sure that you added [numpydoc docstrings](#docstringExample) to your functions. This way the api documentation will be parsed properly.
 * If it is a larger change or an newly added feature or workflow, please place an example of use in the [tobac-tutorials](https://github.com/climate-processes/tobac-tutorials) repository or adapt the existing examples there.
 * If necessary add a folder or modify a file.
-* The code should be PEP 8 compliant, as this facilitates our collaboration. Please use the latest version of [black](https://black.readthedocs.io/en/stable/) to format your code. When you submit a pull request, all files are checked for formatting.
+* The code should be PEP 8 compliant, as this facilitates our collaboration. Please use the latest version (22.6.0) of [black](https://black.readthedocs.io/en/stable/) to format your code. When you submit a pull request, all files are checked for formatting.
 * The tobac repository is set up with pre-commit hooks to automatically format your code when commiting changes. Please run the command "pre-commit install" in the root directory of tobac to set up pre-commit formatting.
 
 We aim to respond to all new issues/pull requests as soon as possible, however at times this is not possible due to work commitments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Please create a new issue on [GitHub](https://github.com/climate-processes/tobac
 * Before you start a pull request, please make sure that you added [numpydoc docstrings](#docstringExample) to your functions. This way the api documentation will be parsed properly.
 * If it is a larger change or an newly added feature or workflow, please place an example of use in the [tobac-tutorials](https://github.com/climate-processes/tobac-tutorials) repository or adapt the existing examples there.
 * If necessary add a folder or modify a file.
-* The code should be PEP 8 compliant, as this facilitates our collaboration. Please use the latest version (22.6.0) of [black](https://black.readthedocs.io/en/stable/) to format your code. When you submit a pull request, all files are checked for formatting.
+* The code should be PEP 8 compliant, as this facilitates our collaboration. Please use the first stable version (22.6.0) of [black](https://black.readthedocs.io/en/stable/) to format your code. When you submit a pull request, all files are checked for formatting.
 * The tobac repository is set up with pre-commit hooks to automatically format your code when commiting changes. Please run the command "pre-commit install" in the root directory of tobac to set up pre-commit formatting.
 
 We aim to respond to all new issues/pull requests as soon as possible, however at times this is not possible due to work commitments.


### PR DESCRIPTION
This PR specifies the version of `black` we use to check formatting.

Should resolve #160.


* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [ ] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [ ] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

