### PR TITLE
Implementing Workarounds and Test for method='prediction'

### DIFF
--- a/tobac/tests/test_tracking.py
+++ b/tobac/tests/test_tracking.py
@@ -5,6 +5,7 @@ import pytest
 import tobac.testing
 import tobac.tracking
 import copy
+import pandas as pd
 from pandas.testing import assert_frame_equal
 import numpy as np
 
@@ -45,4 +46,58 @@ def test_linking_trackpy():
     actual_out_feature["cell"] = actual_out_feature["cell"].astype(float)
     assert_frame_equal(
         expected_out_feature.sort_index(axis=1), actual_out_feature.sort_index(axis=1)
+    )
+
+def test_trackpy_predict():
+    """Function to test if linking_trackpy() with method='predict' correctly links two 
+    features at constant speeds crossing each other.
+    """
+
+    cell_1 = tobac.testing.generate_single_feature(
+        1,
+        1,
+        min_h1=0,
+        max_h1=100,
+        min_h2=0,
+        max_h2=100,
+        frame_start=0,
+        num_frames=5,
+        spd_h1=20,
+        spd_h2=20,
+    )
+
+    cell_1_expected = copy.deepcopy(cell_1)
+    cell_1_expected["cell"] = 1
+
+    cell_2 = tobac.testing.generate_single_feature(
+        1,
+        100,
+        min_h1=0,
+        max_h1=100,
+        min_h2=0,
+        max_h2=100,
+        frame_start=0,
+        num_frames=5,
+        spd_h1=20,
+        spd_h2=-20,
+    )
+
+    cell_2_expected = copy.deepcopy(cell_2)
+    cell_2_expected["cell"] = 2
+
+    features = pd.concat([cell_1, cell_2])
+    expected_output = pd.concat([cell_1_expected, cell_2_expected])
+
+    output = tobac.linking_trackpy(features, 
+                                None, 
+                                1, 
+                                1, 
+                                d_max=100,
+                                method_linking='predict')
+    output = output[
+        ["hdim_1", "hdim_2", "frame", "time",  "feature", "cell"]
+    ]
+
+    assert_frame_equal(
+        expected_output.sort_index(), output.sort_index()
     )

--- a/tobac/tests/test_tracking.py
+++ b/tobac/tests/test_tracking.py
@@ -92,6 +92,15 @@ def test_trackpy_predict():
     output = tobac.linking_trackpy(
         features, None, 1, 1, d_max=100, method_linking="predict"
     )
+
+    output_random = tobac.linking_trackpy(
+        features, None, 1, 1, d_max=100, method_linking="random"
+    )
+
+    # check that the two methods of linking produce different results for this case
+    assert not output_random.equals(output)
+
+    # sorting and dropping indices for comparison with the expected output
     output = output[["hdim_1", "hdim_2", "frame", "time", "feature", "cell"]]
 
     assert_frame_equal(expected_output.sort_index(), output.sort_index())

--- a/tobac/tests/test_tracking.py
+++ b/tobac/tests/test_tracking.py
@@ -48,8 +48,9 @@ def test_linking_trackpy():
         expected_out_feature.sort_index(axis=1), actual_out_feature.sort_index(axis=1)
     )
 
+
 def test_trackpy_predict():
-    """Function to test if linking_trackpy() with method='predict' correctly links two 
+    """Function to test if linking_trackpy() with method='predict' correctly links two
     features at constant speeds crossing each other.
     """
 
@@ -88,16 +89,9 @@ def test_trackpy_predict():
     features = pd.concat([cell_1, cell_2])
     expected_output = pd.concat([cell_1_expected, cell_2_expected])
 
-    output = tobac.linking_trackpy(features, 
-                                None, 
-                                1, 
-                                1, 
-                                d_max=100,
-                                method_linking='predict')
-    output = output[
-        ["hdim_1", "hdim_2", "frame", "time",  "feature", "cell"]
-    ]
-
-    assert_frame_equal(
-        expected_output.sort_index(), output.sort_index()
+    output = tobac.linking_trackpy(
+        features, None, 1, 1, d_max=100, method_linking="predict"
     )
+    output = output[["hdim_1", "hdim_2", "frame", "time", "feature", "cell"]]
+
+    assert_frame_equal(expected_output.sort_index(), output.sort_index())

--- a/tobac/tracking.py
+++ b/tobac/tracking.py
@@ -117,7 +117,9 @@ def linking_trackpy(
         features.rename(columns={"hdim_1": "y", "hdim_2": "x"}, inplace=True)
 
         # generate list of features as input for df_link_iter to avoid bug in df_link
-        features_linking_list = [frame for i, frame in features.groupby("frame", sort=True)]
+        features_linking_list = [
+            frame for i, frame in features.groupby("frame", sort=True)
+        ]
 
         pred = tp.predict.NearestVelocityPredict(span=1)
         trajectories_unfiltered = pred.link_df_iter(

--- a/tobac/tracking.py
+++ b/tobac/tracking.py
@@ -113,6 +113,9 @@ def linking_trackpy(
         )
     elif method_linking == "predict":
 
+        # avoid setting pos_columns by renaimng to default values to avoid trackpy bug
+        features.rename(columns={"hdim_1": "x", "hdim_2": "y"}, inplace=True)
+
         # generate list of features as input for df_link_iter to avoid bug in df_link
         features_linking_list = [frame for i, frame in features.groupby("frame")]
 
@@ -121,7 +124,7 @@ def linking_trackpy(
             features_linking_list,
             search_range=search_range,
             memory=memory,
-            pos_columns=["hdim_1", "hdim_2"],
+            #pos_columns=["hdim_1", "hdim_2"], # not working atm
             t_column="frame",
             neighbor_strategy="KDTree",
             link_strategy="auto",
@@ -133,6 +136,12 @@ def linking_trackpy(
         )
         # recreate a single dataframe from the list
         trajectories_unfiltered = pd.concat(trajectories_unfiltered)
+
+        # change to column names back
+        trajectories_unfiltered.rename(
+            columns={"x": "hdim_1", "y": "hdim_2"}, inplace=True
+        )
+        features.rename(columns={"x": "hdim_1", "y": "hdim_2"}, inplace=True)
     else:
         raise ValueError("method_linking unknown")
 

--- a/tobac/tracking.py
+++ b/tobac/tracking.py
@@ -124,7 +124,7 @@ def linking_trackpy(
             features_linking_list,
             search_range=search_range,
             memory=memory,
-            #pos_columns=["hdim_1", "hdim_2"], # not working atm
+            # pos_columns=["hdim_1", "hdim_2"], # not working atm
             t_column="frame",
             neighbor_strategy="KDTree",
             link_strategy="auto",

--- a/tobac/tracking.py
+++ b/tobac/tracking.py
@@ -114,10 +114,10 @@ def linking_trackpy(
     elif method_linking == "predict":
 
         # avoid setting pos_columns by renaimng to default values to avoid trackpy bug
-        features.rename(columns={"hdim_1": "x", "hdim_2": "y"}, inplace=True)
+        features.rename(columns={"hdim_1": "y", "hdim_2": "x"}, inplace=True)
 
         # generate list of features as input for df_link_iter to avoid bug in df_link
-        features_linking_list = [frame for i, frame in features.groupby("frame")]
+        features_linking_list = [frame for i, frame in features.groupby("frame", sort=True)]
 
         pred = tp.predict.NearestVelocityPredict(span=1)
         trajectories_unfiltered = pred.link_df_iter(
@@ -139,9 +139,9 @@ def linking_trackpy(
 
         # change to column names back
         trajectories_unfiltered.rename(
-            columns={"x": "hdim_1", "y": "hdim_2"}, inplace=True
+            columns={"y": "hdim_1", "x": "hdim_2"}, inplace=True
         )
-        features.rename(columns={"x": "hdim_1", "y": "hdim_2"}, inplace=True)
+        features.rename(columns={"y": "hdim_1", "x": "hdim_2"}, inplace=True)
     else:
         raise ValueError("method_linking unknown")
 

--- a/tobac/tracking.py
+++ b/tobac/tracking.py
@@ -113,9 +113,12 @@ def linking_trackpy(
         )
     elif method_linking == "predict":
 
+        # generate list of features as input for df_link_iter to avoid bug in df_link
+        features_linking_list = [frame for i, frame in features.groupby("frame")]
+
         pred = tp.predict.NearestVelocityPredict(span=1)
-        trajectories_unfiltered = pred.link_df(
-            features_linking,
+        trajectories_unfiltered = pred.link_df_iter(
+            features_linking_list,
             search_range=search_range,
             memory=memory,
             pos_columns=["hdim_1", "hdim_2"],
@@ -128,6 +131,8 @@ def linking_trackpy(
             #                                 hash_size=None, box_size=None, verify_integrity=True,
             #                                 retain_index=False
         )
+        # recreate a single dataframe from the list
+        trajectories_unfiltered = pd.concat(trajectories_unfiltered)
     else:
         raise ValueError("method_linking unknown")
 


### PR DESCRIPTION
This PR aims at solving #169 temporarily by implementing two workarounds for problems upstream in trackpys predictive tracking in `linking_trackpy()`:

1. Switching to `link_df_iter` from `link_df` since the latter method isn't working correctly.
2. Avoiding to set `pos_columns` in `link_df_iter`, because this causes incorrect tracking.

The issue in trackpy for reference: https://github.com/soft-matter/trackpy/issues/699

Furthermore a test to check whether prediction works correctly is added

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [x] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [x] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 
not needed: 
* [ ] If you have introduced a new functionality, have you added an example notebook?

