### PR TITLE
Raise NotImplementedError when using extrapolation

### DIFF
--- a/tobac/tests/test_tracking.py
+++ b/tobac/tests/test_tracking.py
@@ -141,3 +141,26 @@ def test_trackpy_predict():
     output = output[["hdim_1", "hdim_2", "frame", "time", "feature", "cell"]]
 
     assert_frame_equal(expected_output.sort_index(), output.sort_index())
+
+
+def test_tracking_extrapolation():
+    """Tests the extrapolation capabilities of tracking.
+    Right now, this is not implemented, so it will raise an error.
+    """
+
+    cell_1 = tobac.testing.generate_single_feature(
+        1,
+        1,
+        min_h1=0,
+        max_h1=100,
+        min_h2=0,
+        max_h2=100,
+        frame_start=0,
+        num_frames=5,
+        spd_h1=20,
+        spd_h2=20,
+    )
+    with pytest.raises(NotImplementedError):
+        output = tobac.linking_trackpy(
+            cell_1, None, 1, 1, d_max=100, method_linking="predict", extrapolate=1
+        )

--- a/tobac/tracking.py
+++ b/tobac/tracking.py
@@ -166,6 +166,11 @@ def linking_trackpy(
         If method_linking is neither 'random' nor 'predict'.
     """
 
+    if extrapolate != 0:
+        raise NotImplementedError(
+            "Extrapolation is not yet implemented. Set this parameter to 0 to continue."
+        )
+
     #    from trackpy import link_df
     import trackpy as tp
     from copy import deepcopy


### PR DESCRIPTION
Resolves the first part of #165 by raising a `NotImplementedError` when users try to use extrapolation. 

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [x] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

