### PR TITLE
Bug fix: Assure that feature dataframe indices are unique

### DIFF
--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -505,7 +505,7 @@ def feature_detection_multithreshold_timestep(
         )
         if any([x is not None for x in features_threshold_i]):
             features_thresholds = pd.concat(
-                [features_thresholds, features_threshold_i], drop_index=True
+                [features_thresholds, features_threshold_i], ignore_index=True
             )
 
         # For multiple threshold, and features found both in the current and previous step, remove "parent" features from Dataframe

--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -504,7 +504,9 @@ def feature_detection_multithreshold_timestep(
             idx_start=idx_start,
         )
         if any([x is not None for x in features_threshold_i]):
-            features_thresholds = pd.concat([features_thresholds, features_threshold_i], drop_index= True)
+            features_thresholds = pd.concat(
+                [features_thresholds, features_threshold_i], drop_index=True
+            )
 
         # For multiple threshold, and features found both in the current and previous step, remove "parent" features from Dataframe
         if i_threshold > 0 and not features_thresholds.empty and regions_old:

--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -504,7 +504,7 @@ def feature_detection_multithreshold_timestep(
             idx_start=idx_start,
         )
         if any([x is not None for x in features_threshold_i]):
-            features_thresholds = pd.concat([features_thresholds, features_threshold_i])
+            features_thresholds = pd.concat([features_thresholds, features_threshold_i], drop_index= True)
 
         # For multiple threshold, and features found both in the current and previous step, remove "parent" features from Dataframe
         if i_threshold > 0 and not features_thresholds.empty and regions_old:

--- a/tobac/tests/test_feature_detection.py
+++ b/tobac/tests/test_feature_detection.py
@@ -60,6 +60,7 @@ def test_filter_min_distance(test_threshs, min_distance, dxy):
     Tests ```tobac.feature_detection.filter_min_distance
     """
     # start by building a simple dataset with two features close to each other
+    import numpy as np
 
     test_dset_size = (50, 50)
     test_hdim_1_pt = 20.0

--- a/tobac/tests/test_feature_detection.py
+++ b/tobac/tests/test_feature_detection.py
@@ -53,6 +53,70 @@ def test_feature_detection_multithreshold_timestep(
     assert fd_output.iloc[0]["hdim_2"] == pytest.approx(test_hdim_2_pt)
 
 
+@pytest.mark.parametrize("test_threshs, min_distance, dxy",[ ([1,2,3], 100000, 10000) ] )
+def test_filter_min_distance(
+    test_threshs, min_distance, dxy):
+    """
+    Tests ```tobac.feature_detection.filter_min_distance
+    """
+    # start by building a simple dataset with two features close to each other
+
+    test_dset_size = (50, 50)
+    test_hdim_1_pt = 20.0
+    test_hdim_2_pt = 20.0
+    test_hdim_1_sz = 5
+    test_hdim_2_sz = 5
+    test_amp = 5
+    test_min_num = 2
+
+    test_data = np.zeros(test_dset_size)
+    test_data = tbtest.make_feature_blob(
+        test_data,
+        test_hdim_1_pt,
+        test_hdim_2_pt,
+        h1_size=test_hdim_1_sz,
+        h2_size=test_hdim_2_sz,
+        amplitude=test_amp,
+    )
+
+
+    ## add another blob with smaller value
+    test_hdim_1_pt2 = 25.0
+    test_hdim_2_pt2 = 25.0
+    test_hdim_1_sz2 = 2
+    test_hdim_2_sz2 = 2
+    test_amp2 = 3
+    test_data = tbtest.make_feature_blob(
+    test_data,
+    test_hdim_1_pt2,
+    test_hdim_2_pt2,
+    h1_size=test_hdim_1_sz2,
+    h2_size=test_hdim_2_sz2,
+    amplitude=test_amp2,
+)
+    test_data_iris = tbtest.make_dataset_from_arr(test_data, data_type="iris")
+
+    # identify these features
+    fd_output = feat_detect.feature_detection_multithreshold_timestep(
+        test_data_iris,
+        0,
+        threshold=test_threshs,
+        n_min_threshold=test_min_num,
+        min_distance=min_distance,
+        dxy=dxy
+    )
+
+    # check if it function to filter
+    fd_filtered = feat_detect.filter_min_distance(fd_output, dxy, min_distance)
+
+    # Make sure we have only one feature (small feature in minimum distance should be removed )
+    assert len(fd_output.index) == 2
+    assert len(fd_filtered.index ) == 1 
+    # Make sure that the locations of the features is correct (should correspond to locations of first feature)
+    assert fd_filtered.iloc[0]["hdim_1"] == pytest.approx(test_hdim_1_pt)
+    assert fd_filtered.iloc[0]["hdim_2"] == pytest.approx(test_hdim_2_pt)
+
+
 @pytest.mark.parametrize(
     "position_threshold", [("center"), ("extreme"), ("weighted_diff"), ("weighted_abs")]
 )

--- a/tobac/tests/test_feature_detection.py
+++ b/tobac/tests/test_feature_detection.py
@@ -11,7 +11,7 @@ def test_feature_detection_multithreshold_timestep(
     test_threshs, dxy, wavelength_filtering
 ):
     """
-    Tests ```tobac.feature_detection.feature_detection_multithreshold_timestep
+    Tests ```tobac.feature_detection.feature_detection_multithreshold_timestep```
     """
     import numpy as np
 
@@ -57,7 +57,7 @@ def test_feature_detection_multithreshold_timestep(
 )
 def test_filter_min_distance(test_threshs, min_distance, dxy):
     """
-    Tests ```tobac.feature_detection.filter_min_distance
+    Tests ```tobac.feature_detection.filter_min_distance```
     """
     # start by building a simple dataset with two features close to each other
     import numpy as np

--- a/tobac/tests/test_feature_detection.py
+++ b/tobac/tests/test_feature_detection.py
@@ -14,7 +14,6 @@ def test_feature_detection_multithreshold_timestep(
     Tests ```tobac.feature_detection.feature_detection_multithreshold_timestep
     """
     import numpy as np
-    from tobac import feature_detection
 
     # start by building a simple dataset with a single feature and seeing
     # if we identify it
@@ -37,7 +36,7 @@ def test_feature_detection_multithreshold_timestep(
         amplitude=test_amp,
     )
     test_data_iris = tbtest.make_dataset_from_arr(test_data, data_type="iris")
-    fd_output = feature_detection.feature_detection_multithreshold_timestep(
+    fd_output = feat_detect.feature_detection_multithreshold_timestep(
         test_data_iris,
         0,
         threshold=test_threshs,

--- a/tobac/tests/test_feature_detection.py
+++ b/tobac/tests/test_feature_detection.py
@@ -52,9 +52,10 @@ def test_feature_detection_multithreshold_timestep(
     assert fd_output.iloc[0]["hdim_2"] == pytest.approx(test_hdim_2_pt)
 
 
-@pytest.mark.parametrize("test_threshs, min_distance, dxy",[ ([1,2,3], 100000, 10000) ] )
-def test_filter_min_distance(
-    test_threshs, min_distance, dxy):
+@pytest.mark.parametrize(
+    "test_threshs, min_distance, dxy", [([1, 2, 3], 100000, 10000)]
+)
+def test_filter_min_distance(test_threshs, min_distance, dxy):
     """
     Tests ```tobac.feature_detection.filter_min_distance
     """
@@ -78,7 +79,6 @@ def test_filter_min_distance(
         amplitude=test_amp,
     )
 
-
     ## add another blob with smaller value
     test_hdim_1_pt2 = 25.0
     test_hdim_2_pt2 = 25.0
@@ -86,13 +86,13 @@ def test_filter_min_distance(
     test_hdim_2_sz2 = 2
     test_amp2 = 3
     test_data = tbtest.make_feature_blob(
-    test_data,
-    test_hdim_1_pt2,
-    test_hdim_2_pt2,
-    h1_size=test_hdim_1_sz2,
-    h2_size=test_hdim_2_sz2,
-    amplitude=test_amp2,
-)
+        test_data,
+        test_hdim_1_pt2,
+        test_hdim_2_pt2,
+        h1_size=test_hdim_1_sz2,
+        h2_size=test_hdim_2_sz2,
+        amplitude=test_amp2,
+    )
     test_data_iris = tbtest.make_dataset_from_arr(test_data, data_type="iris")
 
     # identify these features
@@ -102,7 +102,7 @@ def test_filter_min_distance(
         threshold=test_threshs,
         n_min_threshold=test_min_num,
         min_distance=min_distance,
-        dxy=dxy
+        dxy=dxy,
     )
 
     # check if it function to filter
@@ -110,7 +110,7 @@ def test_filter_min_distance(
 
     # Make sure we have only one feature (small feature in minimum distance should be removed )
     assert len(fd_output.index) == 2
-    assert len(fd_filtered.index ) == 1 
+    assert len(fd_filtered.index) == 1
     # Make sure that the locations of the features is correct (should correspond to locations of first feature)
     assert fd_filtered.iloc[0]["hdim_1"] == pytest.approx(test_hdim_1_pt)
     assert fd_filtered.iloc[0]["hdim_2"] == pytest.approx(test_hdim_2_pt)


### PR DESCRIPTION
The feature detection does currently not work when  `min_distance` is not 0. An exception is raised in `filter_min_distance()` , because the input feature dataframe for this function can contain index values that are double-defined as a consequence of  concatenating dataframes in `feature_detection_multithreshold_timestep()`. This PR solves #184 by assuring that the feature dataframe that is created in `feature_detection_multithreshold_timestep()` gets unique indices. 

I also added a test for  `filter_min_distance()` to test if features are removed as expected within a specified minimum distance and I removed redundant imports from `test_feature_detection.py`. 



* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [x] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

