### PR TITLE
Deprecate Python 3.6 and lower support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .vscode
 htmlcov
 .coverage
+build

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Detailed documentation of the package can be found at https://tobac.readthedocs.
 
 Installation
 ------------
-tobac now works for both Python 3 and Python 2 installations.
+tobac requires Python 3, and support for Python versions before 3.7 (i.e., 3.6 and lower) is deprecated and will be removed in tobac version 1.5.
 
 The easiest way is to install the most recent version of tobac via conda and the conda-forge channel:
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
 from setuptools import setup
 
-import sys
-import warnings
-
 """
 This code is from the python documentation and is
 designed to read in the version number.
@@ -24,14 +21,6 @@ def get_version(pkg_name):
             return line.split(delim)[1]
     else:
         raise RuntimeError("Unable to find version string.")
-
-
-if sys.version_info < (3, 7):
-    warnings.warn(
-        "Support for Python versions less than 3.7 is deprecated. "
-        "Version 1.5 of tobac will require Python 3.7 or later.",
-        DeprecationWarning,
-    )
 
 
 PACKAGE_NAME = "tobac"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup
 
+import sys
 
 """
 This code is from the python documentation and is
@@ -24,13 +25,42 @@ def get_version(pkg_name):
         raise RuntimeError("Unable to find version string.")
 
 
+if sys.version_info < (3, 7):
+    raise RuntimeError("tobac requires Python 3.7 or higher.")
+
+
 PACKAGE_NAME = "tobac"
+
+# See classifiers list at: https://pypi.org/classifiers/
+CLASSIFIERS = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Education",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft :: Windows",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Atmospheric Science",
+]
+
 
 setup(
     name=PACKAGE_NAME,
     version=get_version(PACKAGE_NAME),
     description="Tracking and object-based analysis of clouds",
     url="http://github.com/tobac-project/tobac",
+    classifiers=CLASSIFIERS,
     author=[
         "Max Heikenfeld",
         "William Jones",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup
 
 import sys
+import warnings
 
 """
 This code is from the python documentation and is
@@ -26,7 +27,11 @@ def get_version(pkg_name):
 
 
 if sys.version_info < (3, 7):
-    raise RuntimeError("tobac requires Python 3.7 or higher.")
+    warnings.warn(
+        "Support for Python versions less than 3.7 is deprecated. "
+        "Version 1.5 of tobac will require Python 3.7 or later.",
+        DeprecationWarning,
+    )
 
 
 PACKAGE_NAME = "tobac"

--- a/tobac/__init__.py
+++ b/tobac/__init__.py
@@ -1,4 +1,17 @@
 # from .tracking import maketrack
+import sys
+
+if sys.version_info < (3, 7):
+    warning = """ \n\n 
+    Support for Python versions less than 3.7 is deprecated. 
+    Version 1.5 of tobac will require Python 3.7 or later.
+   Python {py} detected. \n\n
+    """.format(
+        py=".".join(str(v) for v in sys.version_info[:3])
+    )
+
+    print(warning)
+
 from .segmentation import (
     segmentation_3D,
     segmentation_2D,


### PR DESCRIPTION
Resolves the first half of #185. Rather than dropping support for <3.7, I'm proposing that we only deprecate it in the code. We will still tell conda-forge that we require >=3.7, but this allows users who must remain on old versions to stick around for now. We will drop support with v1.5, as I'd really like to start adding typing annotations. 

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [ ] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

