### PR TITLE
Add DeprecationWarnings to several old functions

### DIFF
--- a/tobac/centerofgravity.py
+++ b/tobac/centerofgravity.py
@@ -2,6 +2,7 @@
 """
 
 import logging
+import warnings
 
 
 def calculate_cog(tracks, mass, mask):
@@ -30,6 +31,11 @@ def calculate_cog(tracks, mass, mask):
 
     from .utils import mask_cube_cell
     from iris import Constraint
+
+    warnings.warn(
+        "calculate_cog is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
 
     logging.info("start calculating centre of gravity for tracked cells")
 
@@ -77,6 +83,11 @@ def calculate_cog_untracked(mass, mask):
     from .utils import mask_cube_untracked
     from iris import Constraint
 
+    warnings.warn(
+        "calculate_cog_untracked is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
+
     logging.info(
         "start calculating centre of gravity for untracked parts of the domain"
     )
@@ -122,6 +133,11 @@ def calculate_cog_domain(mass):
 
     from pandas import DataFrame
     from iris import Constraint
+
+    warnings.warn(
+        "calculate_cog_domain is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
 
     logging.info("start calculating centre of gravity for entire domain")
 
@@ -172,6 +188,11 @@ def center_of_gravity(cube_in):
 
     from iris.analysis import SUM
     import numpy as np
+
+    warnings.warn(
+        "center_of_gravity is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
 
     cube_sum = cube_in.collapsed(["bottom_top", "south_north", "west_east"], SUM)
     z = cube_in.coord("geopotential_height")

--- a/tobac/plotting.py
+++ b/tobac/plotting.py
@@ -565,6 +565,10 @@ def plot_mask_cell_track_follow(
     Input:
     Output:
     """
+    warnings.warn(
+        "plot_mask_cell_track_follow is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
 
     mpl_backend = mpl.get_backend()
     if mpl_backend != "agg":
@@ -704,6 +708,11 @@ def plot_mask_cell_individual_follow(
     from .utils import mask_cell_surface
     from mpl_toolkits.axes_grid1 import make_axes_locatable
     from matplotlib.colors import Normalize
+
+    warnings.warn(
+        "plot_mask_cell_individual_follow is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
 
     divider = make_axes_locatable(axes)
 
@@ -891,6 +900,12 @@ def plot_mask_cell_track_static(
     Input:
     Output:
     """
+
+    warnings.warn(
+        "plot_mask_cell_track_static is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
+
     mpl_backend = mpl.get_backend()
     if mpl_backend != "agg":
         warnings.warn(
@@ -1056,6 +1071,11 @@ def plot_mask_cell_individual_static(
     from .utils import mask_features, mask_features_surface
     from mpl_toolkits.axes_grid1 import make_axes_locatable
     from matplotlib.colors import Normalize
+
+    warnings.warn(
+        "plot_mask_cell_individual_static is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
 
     divider = make_axes_locatable(axes)
 
@@ -1252,6 +1272,11 @@ def plot_mask_cell_track_2D3Dstatic(
     Input:
     Output:
     """
+    warnings.warn(
+        "plot_mask_cell_track_2D3Dstatic is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
+
     mpl_backend = mpl.get_backend()
     if mpl_backend != "agg":
         warnings.warn(
@@ -1426,6 +1451,11 @@ def plot_mask_cell_track_3Dstatic(
     Input:
     Output:
     """
+    warnings.warn(
+        "plot_mask_cell_track_3Dstatic is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
+
     mpl_backend = mpl.get_backend()
     if mpl_backend != "agg":
         warnings.warn(
@@ -1602,6 +1632,11 @@ def plot_mask_cell_individual_3Dstatic(
     #    from mpl_toolkits.axes_grid1 import make_axes_locatable
     #    from matplotlib.colors import Normalize
     from mpl_toolkits.mplot3d import Axes3D
+
+    warnings.warn(
+        "plot_mask_cell_individual_3Dstatic is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
 
     axes.view_init(elev=ele, azim=azim)
     axes.grid(b=False)
@@ -1782,6 +1817,10 @@ def plot_mask_cell_track_static_timeseries(
     Input:
     Output:
     """
+    warnings.warn(
+        "plot_mask_cell_track_static_timeseries is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
 
     mpl_backend = mpl.get_backend()
     if mpl_backend != "agg":

--- a/tobac/wrapper.py
+++ b/tobac/wrapper.py
@@ -1,5 +1,6 @@
 import numpy as np
 import logging
+import warnings
 
 
 def tracking_wrapper(
@@ -16,6 +17,11 @@ def tracking_wrapper(
     from .tracking import linking_trackpy
     from .segmentation import segmentation_3D, segmentation_2D
     from .utils import get_spacings
+
+    warnings.warn(
+        "tracking_wrapper is depreciated and will be removed in v2.0.",
+        DeprecationWarning,
+    )
 
     logger = logging.getLogger("trackpy")
     logger.propagate = False
@@ -146,6 +152,11 @@ def maketrack(
     
     """
     from copy import deepcopy
+
+    warnings.warn(
+        "maketrack is depreciated and will be removed in v2.0.",
+        DeprecationWarning,
+    )
 
     logger = logging.getLogger("trackpy")
     logger.propagate = False


### PR DESCRIPTION
This PR is simply to add several DeprecationWarnings to various functions that have been discussed before as needing to be removed or substantially reworked for v2.0. Getting these DeprecationWarnings into v1.5 should give users enough time to migrate away from the functions. 

Resolves #198 and #158.

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [ ] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [ ] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [ ] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

