### PR TITLE
Deprecate some analysis functions

### DIFF
--- a/tobac/analysis.py
+++ b/tobac/analysis.py
@@ -30,6 +30,7 @@ import pandas as pd
 import numpy as np
 import logging
 import os
+import warnings
 
 from .utils import mask_cell, mask_cell_surface, mask_cube_cell, get_bounding_box
 
@@ -86,6 +87,11 @@ def cell_statistics_all(
     -------
     None
     """
+    warnings.warn(
+        "cell_statistics_all is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
+
     if cell_selection is None:
         cell_selection = np.unique(track["cell"])
     for cell in cell_selection:
@@ -160,6 +166,11 @@ def cell_statistics(
     from iris.cube import Cube, CubeList
     from iris.coords import AuxCoord
     from iris import Constraint, save
+
+    warnings.warn(
+        "cell_statistics is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
 
     # If input is single cube, turn into cubelist
     if type(input_cubes) is Cube:
@@ -312,6 +323,11 @@ def cog_cell(
     -------
     None
     """
+
+    warnings.warn(
+        "cog_cell is depreciated and will be removed or significantly changed in v2.0.",
+        DeprecationWarning,
+    )
 
     from iris import Constraint
 


### PR DESCRIPTION
As discussed in #146 (and similar to #200), this deprecates three functions in `analysis.py`: `cell_statistics_all`, `cell_statistics`, and `cog_cell`. These functions likely don't work and should be reworked in any event before 2.0. 

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [ ] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

