### PR TITLE
Resolves #212

### DIFF
--- a/tobac/tests/test_tracking.py
+++ b/tobac/tests/test_tracking.py
@@ -185,5 +185,5 @@ def test_argument_logic():
     )
     with pytest.raises(ValueError):
         output = tobac.linking_trackpy(
-            cell_1, None, 1, 1, d_min=None, d_max=None, v_max=None 
+            cell_1, None, 1, 1, d_min=None, d_max=None, v_max=None
         )

--- a/tobac/tests/test_tracking.py
+++ b/tobac/tests/test_tracking.py
@@ -164,3 +164,26 @@ def test_tracking_extrapolation():
         output = tobac.linking_trackpy(
             cell_1, None, 1, 1, d_max=100, method_linking="predict", extrapolate=1
         )
+
+
+def test_argument_logic():
+    """Tests whether missing arguments are handled correctly,
+    i.e. whether a ValueError is raised if neither d_min, d_max nor v_max have
+    been provided to tobac.linking_trackpy.
+    """
+    cell_1 = tobac.testing.generate_single_feature(
+        1,
+        1,
+        min_h1=0,
+        max_h1=100,
+        min_h2=0,
+        max_h2=100,
+        frame_start=0,
+        num_frames=5,
+        spd_h1=20,
+        spd_h2=20,
+    )
+    with pytest.raises(ValueError):
+        output = tobac.linking_trackpy(
+            cell_1, None, 1, 1, d_min=None, d_max=None, v_max=None 
+        )

--- a/tobac/tracking.py
+++ b/tobac/tracking.py
@@ -180,7 +180,7 @@ def linking_trackpy(
 
     if (v_max is None) and (d_min is None) and (d_max is None):
         raise ValueError(
-            "Neither one of d_min, d_max, v_max has been provided. Exactly one of these arguments must be specified."
+            "Neither d_max nor v_max has been provided. Either one of these arguments must be specified."
         )
 
     # calculate search range based on timestep and grid spacing

--- a/tobac/tracking.py
+++ b/tobac/tracking.py
@@ -179,7 +179,9 @@ def linking_trackpy(
     #    from .utils import add_coordinates
 
     if (v_max is None) and (d_min is None) and (d_max is None):
-        raise ValueError("Neither one of d_min, d_max, v_max has been provided. Exactly one of these arguments must be specified.")
+        raise ValueError(
+            "Neither one of d_min, d_max, v_max has been provided. Exactly one of these arguments must be specified."
+        )
 
     # calculate search range based on timestep and grid spacing
     if v_max is not None:

--- a/tobac/tracking.py
+++ b/tobac/tracking.py
@@ -178,6 +178,9 @@ def linking_trackpy(
     #    from trackpy import filter_stubs
     #    from .utils import add_coordinates
 
+    if (v_max is None) and (d_min is None) and (d_max is None):
+        raise ValueError("Neither one of d_min, d_max, v_max has been provided. Exactly one of these arguments must be specified.")
+
     # calculate search range based on timestep and grid spacing
     if v_max is not None:
         search_range = int(dt * v_max / dxy)


### PR DESCRIPTION
This pull request should resolve #212.

A simple check has been added to correctly handle the case of neither `v_max, d_min, d_max` being passed to `linking_trackpy`, i.e. a `ValueError` is raised if all three arguments are missing. A corresponding test case has also been added.

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [x] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [x] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [x] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 