### PR TITLE
Fix 2d coordinate interpolation

### DIFF
--- a/tobac/utils/general.py
+++ b/tobac/utils/general.py
@@ -94,11 +94,15 @@ def add_coordinates(t, variable_cube):
 
             if variable_cube.coord_dims(coord) == (hdim_1, hdim_2):
                 f = interp2d(dimvec_2, dimvec_1, variable_cube.coord(coord).points)
-                coordinate_points = [f(a, b) for a, b in zip(t["hdim_2"], t["hdim_1"])]
+                coordinate_points = np.asarray(
+                    [f(a, b) for a, b in zip(t["hdim_2"], t["hdim_1"])]
+                )
 
             if variable_cube.coord_dims(coord) == (hdim_2, hdim_1):
                 f = interp2d(dimvec_1, dimvec_2, variable_cube.coord(coord).points)
-                coordinate_points = [f(a, b) for a, b in zip(t["hdim_1"], t["hdim_2"])]
+                coordinate_points = np.asarray(
+                    [f(a, b) for a, b in zip(t["hdim_1"], t["hdim_2"])]
+                )
 
         # interpolate 3D coordinates:
         # mainly workaround for wrf latitude and longitude (to be fixed in future)


### PR DESCRIPTION
Fixes the problem with 2d coordinate interpolation producing `object` dtypes in feature_detection raised in #240 that was the cause of the bug in #239 

Ideally this could be released as part of v1.4.2, but the changes to the utils structure as part of v1.5 make it impractical to separate

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [x] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

