### PR TITLE
Fix for `find_axis_from_coord` if the coordinate is not a dimensional coord

### DIFF
--- a/tobac/utils/internal.py
+++ b/tobac/utils/internal.py
@@ -487,12 +487,15 @@ def find_axis_from_coord(variable_cube, coord_name):
     -------
     axis_number: int
         the number of the axis of the given coordinate, or None if the coordinate
-        is not found in the cube
+        is not found in the cube or not a dimensional coordinate
     """
 
     list_coord_names = [coord.name() for coord in variable_cube.coords()]
     all_matching_axes = list(set(list_coord_names) & set((coord_name,)))
-    if len(all_matching_axes) == 1:
+    if (
+        len(all_matching_axes) == 1
+        and len(variable_cube.coord_dims(all_matching_axes[0])) > 0
+    ):
         return variable_cube.coord_dims(all_matching_axes[0])[0]
     elif len(all_matching_axes) > 1:
         raise ValueError("Too many axes matched.")


### PR DESCRIPTION
In cases where the coordinate is no longer a dimensional coordinate (such as after slicing over that dimension), `find_axis_from_coord` would result in an IndexError (see #254). This now returns `None` in the same manner as if the coord was not found in the cube

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

