### PR TITLE
Speedup `combine_tobac_feats`

### DIFF
--- a/tobac/testing.py
+++ b/tobac/testing.py
@@ -815,6 +815,7 @@ def generate_single_feature(
         curr_dict["hdim_1"] = curr_h1
         curr_dict["hdim_2"] = curr_h2
         curr_dict["frame"] = frame_start + i
+        curr_dict["idx"] = 0
         if curr_v is not None:
             curr_dict["vdim"] = curr_v
             curr_v += spd_v

--- a/tobac/tests/test_testing.py
+++ b/tobac/tests/test_testing.py
@@ -111,6 +111,7 @@ def test_generate_single_feature():
                 "vdim": 1,
                 "frame": 0,
                 "feature": 1,
+                "idx": 0,
                 "time": datetime.datetime(2022, 1, 1, 0, 0),
             }
         ]
@@ -131,6 +132,7 @@ def test_generate_single_feature():
                 "hdim_2": 1,
                 "frame": 0,
                 "feature": 1,
+                "idx": 0,
                 "time": datetime.datetime(2022, 1, 1, 0, 0),
             }
         ]
@@ -150,6 +152,7 @@ def test_generate_single_feature():
                 "hdim_2": 1,
                 "frame": 0,
                 "feature": 1,
+                "idx": 0,
                 "time": datetime.datetime(2022, 1, 1, 0, 0),
             },
             {
@@ -157,6 +160,7 @@ def test_generate_single_feature():
                 "hdim_2": 2,
                 "frame": 1,
                 "feature": 2,
+                "idx": 0,
                 "time": datetime.datetime(2022, 1, 1, 0, 5),
             },
             {
@@ -164,6 +168,7 @@ def test_generate_single_feature():
                 "hdim_2": 3,
                 "frame": 2,
                 "feature": 3,
+                "idx": 0,
                 "time": datetime.datetime(2022, 1, 1, 0, 10),
             },
             {
@@ -171,6 +176,7 @@ def test_generate_single_feature():
                 "hdim_2": 4,
                 "frame": 3,
                 "feature": 4,
+                "idx": 0,
                 "time": datetime.datetime(2022, 1, 1, 0, 15),
             },
         ]
@@ -198,6 +204,7 @@ def test_generate_single_feature():
                 "vdim": 1,
                 "frame": 0,
                 "feature": 1,
+                "idx": 0,
                 "time": datetime.datetime(2022, 1, 1, 0, 0),
             },
             {
@@ -206,6 +213,7 @@ def test_generate_single_feature():
                 "vdim": 2,
                 "frame": 1,
                 "feature": 2,
+                "idx": 0,
                 "time": datetime.datetime(2022, 1, 1, 0, 5),
             },
             {
@@ -214,6 +222,7 @@ def test_generate_single_feature():
                 "vdim": 3,
                 "frame": 2,
                 "feature": 3,
+                "idx": 0,
                 "time": datetime.datetime(2022, 1, 1, 0, 10),
             },
             {
@@ -222,6 +231,7 @@ def test_generate_single_feature():
                 "vdim": 4,
                 "frame": 3,
                 "feature": 4,
+                "idx": 0,
                 "time": datetime.datetime(2022, 1, 1, 0, 15),
             },
         ]

--- a/tobac/tests/test_tracking.py
+++ b/tobac/tests/test_tracking.py
@@ -76,7 +76,7 @@ def test_linking_trackpy():
     )
     # Just want to remove the time_cell column here.
     actual_out_feature = actual_out_feature[
-        ["hdim_1", "hdim_2", "frame", "feature", "time", "cell"]
+        ["hdim_1", "hdim_2", "frame", "feature", "time", "cell", "idx"]
     ]
 
     expected_out_feature = convert_cell_dtype_if_appropriate(
@@ -117,7 +117,7 @@ def test_linking_trackpy():
     )
     # Just want to remove the time_cell column here.
     actual_out_feature = actual_out_feature[
-        ["hdim_1", "hdim_2", "vdim", "frame", "feature", "time", "cell"]
+        ["hdim_1", "hdim_2", "vdim", "frame", "feature", "time", "cell", "idx"]
     ]
 
     expected_out_feature = convert_cell_dtype_if_appropriate(
@@ -308,7 +308,7 @@ def test_trackpy_predict():
     assert not output_random.equals(output)
 
     # sorting and dropping indices for comparison with the expected output
-    output = output[["hdim_1", "hdim_2", "frame", "time", "feature", "cell"]]
+    output = output[["hdim_1", "hdim_2", "frame", "idx", "time", "feature", "cell"]]
     expected_output = convert_cell_dtype_if_appropriate(output, expected_output)
 
     assert_frame_equal(expected_output.sort_index(), output.sort_index())

--- a/tobac/utils/general.py
+++ b/tobac/utils/general.py
@@ -72,7 +72,6 @@ def add_coordinates(t, variable_cube):
         logging.debug("adding coord: " + coord)
         # interpolate 2D coordinates:
         if variable_cube.coord(coord).ndim == 1:
-
             if variable_cube.coord_dims(coord) == (hdim_1,):
                 f = interp1d(
                     dimvec_1,
@@ -91,7 +90,6 @@ def add_coordinates(t, variable_cube):
 
         # interpolate 2D coordinates:
         elif variable_cube.coord(coord).ndim == 2:
-
             if variable_cube.coord_dims(coord) == (hdim_1, hdim_2):
                 f = interp2d(dimvec_2, dimvec_1, variable_cube.coord(coord).points)
                 coordinate_points = np.asarray(
@@ -108,7 +106,6 @@ def add_coordinates(t, variable_cube):
         # mainly workaround for wrf latitude and longitude (to be fixed in future)
 
         elif variable_cube.coord(coord).ndim == 3:
-
             if variable_cube.coord_dims(coord) == (ndim_time, hdim_1, hdim_2):
                 f = interp2d(
                     dimvec_2, dimvec_1, variable_cube[0, :, :].coord(coord).points
@@ -155,7 +152,6 @@ def add_coordinates(t, variable_cube):
 def add_coordinates_3D(
     t, variable_cube, vertical_coord="auto", assume_coords_fixed_in_time=True
 ):
-
     """Function adding coordinates from the tracking cube to the trajectories
         for the 3D case: time, longitude&latitude, x&y dimensions, and altitude
 
@@ -539,21 +535,13 @@ def combine_tobac_feats(list_of_feats, preserve_old_feat_nums=None):
     combined_df = pd.concat(list_of_feats)
     # Then, sort by time first, then by feature number
     combined_df = combined_df.sort_values(["time", "feature"])
-    all_times = sorted(combined_df["time"].unique())
-    # Loop through current times
-    start_feat_num = combined_df["feature"].min()
     # Save the old feature numbers if requested.
     if preserve_old_feat_nums is not None:
         combined_df[preserve_old_feat_nums] = combined_df["feature"]
 
-    for frame_num, curr_time in enumerate(all_times):
-        # renumber the frame number
-        combined_df.loc[combined_df["time"] == curr_time, "frame"] = frame_num
-        # renumber the features
-        curr_row_count = len(combined_df.loc[combined_df["time"] == curr_time])
-        feat_num_arr = np.arange(start_feat_num, start_feat_num + curr_row_count)
-        combined_df.loc[combined_df["time"] == curr_time, "feature"] = feat_num_arr
-        start_feat_num = np.max(feat_num_arr) + 1
-
-    combined_df = combined_df.reset_index(drop=True)
-    return combined_df
+    # count_per_time = combined_feats.groupby('time')['index'].count()
+    combined_df["frame"] = combined_df["time"].rank(method="dense").astype(int) - 1
+    combined_sorted = combined_df.sort_values(["frame", "idx"], ignore_index=True)
+    combined_sorted["feature"] = np.arange(1, len(combined_sorted) + 1)
+    combined_sorted = combined_sorted.reset_index(drop=True)
+    return combined_sorted


### PR DESCRIPTION
I sped up `utils.general.combine_tobac_feats` several times by getting rid of `.loc` functions. Because I used the `idx` column in the new `combine_tobac_feats` function (as it is guaranteed to be output by feature detection), I had to add it to the testing generation function and fix some of the tests to expect an `idx` column. 

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [x] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

