### PR TITLE
Set `time_cell` of untracked cells to `NaT`

### DIFF
--- a/tobac/tests/test_tracking.py
+++ b/tobac/tests/test_tracking.py
@@ -362,3 +362,40 @@ def test_argument_logic():
         output = tobac.linking_trackpy(
             cell_1, None, 1, 1, d_min=None, d_max=None, v_max=None
         )
+
+
+def test_untracked_nat():
+    """
+    Tests to make sure that the untracked cells don't have timedelta assigned.
+    """
+    features = tobac.testing.generate_single_feature(
+        1,
+        1,
+        min_h1=0,
+        max_h1=101,
+        min_h2=0,
+        max_h2=101,
+        frame_start=0,
+        num_frames=2,
+        spd_h1=50,
+        spd_h2=50,
+    )
+
+    output = tobac.linking_trackpy(
+        features,
+        None,
+        1,
+        1,
+        d_max=40,
+        method_linking="random",
+        cell_number_unassigned=-1,
+        time_cell_min=2,
+    )
+
+    assert np.all(output["cell"].values == np.array([-1, -1]))
+    # NaT values cannot be compared, so instead we check for null values
+    # and check for the data type
+    assert np.all(pd.isnull(output["time_cell"]))
+    # the exact data type depends on architecture, so
+    # instead just check by name
+    assert output["time_cell"].dtype.name == "timedelta64[ns]"

--- a/tobac/tracking.py
+++ b/tobac/tracking.py
@@ -440,7 +440,9 @@ def linking_trackpy(
     #     add time coordinate relative to cell initiation:
     #    logging.debug('start adding cell time to trajectories')
     trajectories_filtered_filled = trajectories_filtered_unfilled
-    trajectories_final = add_cell_time(trajectories_filtered_filled)
+    trajectories_final = add_cell_time(
+        trajectories_filtered_filled, cell_number_unassigned=cell_number_unassigned
+    )
     # Add metadata
     trajectories_final.attrs["cell_number_unassigned"] = cell_number_unassigned
 
@@ -532,13 +534,15 @@ def fill_gaps(
     return t_out
 
 
-def add_cell_time(t):
+def add_cell_time(t: pd.DataFrame, cell_number_unassigned: int):
     """add cell time as time since the initiation of each cell
 
     Parameters
     ----------
     t : pandas.DataFrame
         trajectories with added coordinates
+    cell_number_unassigned: int
+        unassigned cell value
 
     Returns
     -------
@@ -551,6 +555,7 @@ def add_cell_time(t):
 
     t["time_cell"] = t["time"] - t.groupby("cell")["time"].transform("min")
     t["time_cell"] = pd.to_timedelta(t["time_cell"])
+    t.loc[t["cell"] == cell_number_unassigned, "time_cell"] = pd.Timedelta("nat")
     return t
 
 


### PR DESCRIPTION
Resolves #271 and sets `time_cell` of untracked cells to `NaT`. The way that I checked for this in the tests is a bit odd, but it should avoid machine-specific issues. 

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [x] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [x] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

