### PR TITLE
Allow user to select marker for unsegmented points

### DIFF
--- a/tobac/segmentation.py
+++ b/tobac/segmentation.py
@@ -320,6 +320,8 @@ def segmentation_timestep(
     PBC_flag="none",
     seed_3D_flag="column",
     seed_3D_size=5,
+    below_threshold_num=0,
+    above_threshold_unseg_num=0,
 ):
     """Perform watershedding for an individual time step of the data. Works
     for both 2D and 3D data
@@ -377,7 +379,10 @@ def segmentation_timestep(
         seed area for each dimension separately. Note: we recommend the use
         of odd numbers for this. If you give an even number, your seed box will be
         biased and not centered around the feature.
-
+    below_threshold_num: int
+        the marker to use to indicate a segmentation point is below the threshold.
+    above_threshold_unseg_num: int
+        the marker to use to indicate a segmentation point is above the threshold but unsegmented.
 
     Returns
     -------
@@ -441,6 +446,9 @@ def segmentation_timestep(
         raise ValueError(
             "Segmentation routine only possible with 2 or 3 spatial dimensions"
         )
+
+    if below_threshold_num > 0 or above_threshold_unseg_num > 0:
+        raise ValueError("Below/above threshold markers must be <=0")
 
     # copy feature dataframe for output
     features_out = deepcopy(features_in)
@@ -986,6 +994,9 @@ def segmentation_timestep(
 
     # Finished PBC checks and new PBC updated segmentation now in segmentation_mask.
     # Write resulting mask into cube for output
+    segmentation_mask_cpy = copy.deepcopy(segmentation_mask)
+    segmentation_mask[segmentation_mask_cpy == 0] = above_threshold_unseg_num
+    segmentation_mask[segmentation_mask_cpy == -1] = below_threshold_num
     segmentation_out.data = segmentation_mask
 
     # count number of grid cells associated to each tracked cell and write that into DataFrame:
@@ -1079,6 +1090,8 @@ def segmentation(
     PBC_flag="none",
     seed_3D_flag="column",
     seed_3D_size=5,
+    below_threshold_num=0,
+    above_threshold_unseg_num=0,
 ):
     """Use watershedding to determine region above a threshold
         value around initial seeding position for all time steps of
@@ -1145,6 +1158,10 @@ def segmentation(
             seed area for each dimension separately. Note: we recommend the use
             of odd numbers for this. If you give an even number, your seed box will be
             biased and not centered around the feature.
+        below_threshold_num: int
+            the marker to use to indicate a segmentation point is below the threshold.
+        above_threshold_unseg_num: int
+            the marker to use to indicate a segmentation point is above the threshold but unsegmented.
 
 
         Returns
@@ -1202,6 +1219,8 @@ def segmentation(
             PBC_flag=PBC_flag,
             seed_3D_flag=seed_3D_flag,
             seed_3D_size=seed_3D_size,
+            above_threshold_unseg_num=above_threshold_unseg_num,
+            below_threshold_num=below_threshold_num,
         )
         segmentation_out_list.append(segmentation_out_i)
         features_out_list.append(features_out_i)

--- a/tobac/tests/test_segmentation.py
+++ b/tobac/tests/test_segmentation.py
@@ -932,6 +932,8 @@ def test_empty_segmentation(PBC_flag):
         "dxy": test_dxy,
         "threshold": 1.5,
         "PBC_flag": PBC_flag,
+        "above_threshold_unseg_num": 0,
+        "below_threshold_num": -1,
     }
     test_data_iris = testing.make_dataset_from_arr(
         seg_arr, data_type="iris", z_dim_num=0, y_dim_num=1, x_dim_num=2
@@ -978,6 +980,8 @@ def test_pbc_snake_segmentation():
         PBC_flag="hdim_2",
         seed_3D_flag="box",
         seed_3D_size=3,
+        above_threshold_unseg_num=0,
+        below_threshold_num=-1,
     )
 
     correct_seg_arr = np.full((50, 50), -1, dtype=np.int32)
@@ -1014,6 +1018,8 @@ def test_pbc_snake_segmentation():
         PBC_flag="hdim_1",
         seed_3D_flag="box",
         seed_3D_size=3,
+        above_threshold_unseg_num=0,
+        below_threshold_num=-1,
     )
     seg_out_arr = seg_output.core_data()
 
@@ -1076,3 +1082,52 @@ def test_max_distance():
     seg_out_arr = seg_output.core_data()
     assert np.all(correct_seg_arr == seg_out_arr)
     """
+
+
+@pytest.mark.parametrize(
+    ("below_thresh", "above_thresh", "error"),
+    ((0, 0, False), (0, -1, False), (-5, -10, False), (20, 30, True)),
+)
+def test_seg_alt_unseed_num(below_thresh, above_thresh, error):
+    """
+    Tests ```segmentation.segmentation_timestep``` to
+    make sure that the unseeded regions are labeled appropriately.
+
+    """
+    test_arr = np.zeros((50, 50))
+    test_arr[0:10, 0:10] = 10
+    test_arr[40:50, 40:50] = 10
+
+    fd_output = testing.generate_single_feature(5, 5, max_h1=50, max_h2=50)
+
+    test_data_iris = testing.make_dataset_from_arr(test_arr, data_type="iris")
+    if error:
+        with pytest.raises(ValueError):
+            seg_output, seg_feats = segmentation.segmentation_timestep(
+                test_data_iris,
+                fd_output,
+                1,
+                threshold=1,
+                PBC_flag="none",
+                below_threshold_num=below_thresh,
+                above_threshold_unseg_num=above_thresh,
+            )
+    else:
+        seg_output, seg_feats = segmentation.segmentation_timestep(
+            test_data_iris,
+            fd_output,
+            1,
+            threshold=1,
+            PBC_flag="none",
+            below_threshold_num=below_thresh,
+            above_threshold_unseg_num=above_thresh,
+        )
+
+        correct_seg_arr = np.full((50, 50), below_thresh, dtype=np.int32)
+        feat_num: int = 1
+        correct_seg_arr[0:10, 0:10] = feat_num
+        correct_seg_arr[10:40, 10:40] = below_thresh
+        correct_seg_arr[40:50, 40:50] = above_thresh
+
+        seg_out_arr = seg_output.core_data()
+        assert np.all(correct_seg_arr == seg_out_arr)


### PR DESCRIPTION
Resolves #62 and allows the user to select the marker for unsegmented points. This actually accomplishes two goals, as it reverts the default for segmentation (that all unsegmented points are `0`) back to what it was before the introduction of PBCs into this release. 

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [x] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [x] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

