### PR TITLE
Automatically find requirements in setup.py, add new dev and example requirement files and update check_formatting action to use conda instead of pip

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -18,5 +18,5 @@ jobs:
       - name: Install dependencies and check formatting
         shell: bash -l {0}
         run:
-          mamba install --quiet --yes --file requirements.txt &&
+          mamba install --quiet --yes --file requirements.txt black &&
           black tobac --check

--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -5,10 +5,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - name: Set up conda
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: '3.8'
-      - run: pip install .
-      - run: pip install black==22.6.0 
-      - run: black tobac --check
-      
+          miniforge-version: latest
+          miniforge-variant: mambaforge
+          channel-priority: strict
+          channels: conda-forge
+          show-channel-urls: true
+          use-only-tar-bz2: true
+
+      - name: Install dependencies and check formatting
+        shell: bash -l {0}
+        run:
+          mamba install --quiet --yes --file requirements.txt &&
+          black tobac --check

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -9,3 +9,7 @@ iris
 xarray
 cartopy
 trackpy
+pre-commit
+black
+pytest
+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,6 +34,7 @@ master_doc = "index"
 # allow dropdowns
 collapse_navigation = False
 
+
 # Include our custom CSS (currently for special table config)
 def setup(app):
     app.add_css_file("theme_overrides.css")

--- a/example_requirements.txt
+++ b/example_requirements.txt
@@ -9,3 +9,7 @@ iris
 xarray
 cartopy
 trackpy
+jupyter
+notebook
+pytables
+pyart

--- a/setup.py
+++ b/setup.py
@@ -22,16 +22,20 @@ def get_version(pkg_name):
     else:
         raise RuntimeError("Unable to find version string.")
 
+
 def get_requirements(requirements_filename):
     requirements_file = Path(__file__).parent / requirements_filename
     assert requirements_file.exists()
     with open(requirements_file) as f:
-        requirements = [line.strip() for line in f.readlines() if not line.startswith("#")]
+        requirements = [
+            line.strip() for line in f.readlines() if not line.startswith("#")
+        ]
     # Iris has a different name on PyPI...
     if "iris" in requirements:
         requirements.remove("iris")
         requirements.append("scitools-iris")
     return requirements
+
 
 PACKAGE_NAME = "tobac"
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         "max.heikenfeld@physics.ox.ac.uk",
         "william.jones@physics.ox.ac.uk",
         "senf@tropos.de",
-        "sean.freeman@colostate.edu",
+        "sean.freeman@uah.edu",
         "julia.kukulies@gu.se",
         "peter.marinescu@colostate.edu",
     ],

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,10 @@ def get_requirements(requirements_filename):
     assert requirements_file.exists()
     with open(requirements_file) as f:
         requirements = [line.strip() for line in f.readlines() if not line.startswith("#")]
+    # Iris has a different name on PyPI...
+    if "iris" in requirements:
+        requirements.remove("iris")
+        requirements.append("scitools-iris")
     return requirements
 
 PACKAGE_NAME = "tobac"

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,12 @@ def get_version(pkg_name):
     else:
         raise RuntimeError("Unable to find version string.")
 
+def get_requirements(requirements_filename):
+    requirements_file = Path(__file__).parent / requirements_filename
+    assert requirements_file.exists()
+    with open(requirements_file) as f:
+        requirements = [line.strip() for line in f.readlines() if not line.startswith("#")]
+    return requirements
 
 PACKAGE_NAME = "tobac"
 
@@ -73,18 +79,7 @@ setup(
     ],
     license="BSD-3-Clause License",
     packages=[PACKAGE_NAME, PACKAGE_NAME + ".utils"],
-    install_requires=[
-        "numpy",
-        "scipy",
-        "scikit-image",
-        "scikit-learn",
-        "pandas",
-        "matplotlib",
-        "xarray",
-        "trackpy",
-    ],
-    test_requires=[
-        "pytest",
-    ],
+    install_requires=get_requirements("requirements.txt"),
+    test_requires=["pytest"],
     zip_safe=False,
 )

--- a/tobac/analysis.py
+++ b/tobac/analysis.py
@@ -245,7 +245,6 @@ def cell_statistics(
             cube_masked = mask_cube_cell(cube, mask_cell_i, cell, track_i)
             coords_remove = []
             for coordinate in cube_masked.coords(dim_coords=False):
-
                 if coordinate.name() not in dimensions:
                     for dim in dimensions:
                         if set(cube_masked.coord_dims(coordinate)).intersection(

--- a/tobac/plotting.py
+++ b/tobac/plotting.py
@@ -356,7 +356,6 @@ def plot_tracks_mask_field(
     if np.any(
         ~np.isnan(field.data)
     ):  # check if field to plot is not only nan, which causes error:
-
         plot_field = iplt.contourf(
             field,
             coords=["longitude", "latitude"],
@@ -584,7 +583,6 @@ def plot_mask_cell_track_follow(
 
     track_cell = track[track["cell"] == cell]
     for i_row, row in track_cell.iterrows():
-
         constraint_time = Constraint(time=row["time"])
         constraint_x = Constraint(
             projection_x_coordinate=lambda cell: row["projection_x_coordinate"] - width
@@ -838,7 +836,6 @@ def plot_mask_cell_individual_follow(
         )
 
     if cog is not None:
-
         for i_row, row in cog.iterrows():
             cell = row["cell"]
 
@@ -857,7 +854,6 @@ def plot_mask_cell_individual_follow(
             )
 
     if features is not None:
-
         for i_row, row in features.iterrows():
             color = "purple"
             axes.plot(
@@ -934,7 +930,6 @@ def plot_mask_cell_track_static(
     )
     time_cell = time[slice(i_start, i_end)]
     for time_i in time_cell:
-
         #    for i_row,row in track_cell.iterrows():
         #        time_i=row['time']
         #        constraint_time = Constraint(time=row['time'])
@@ -1208,7 +1203,6 @@ def plot_mask_cell_individual_static(
             linewidth=1,
         )
     if cog is not None:
-
         for i_row, row in cog.iterrows():
             cell = row["cell"]
 
@@ -1227,7 +1221,6 @@ def plot_mask_cell_individual_static(
             )
 
     if features is not None:
-
         for i_row, row in features.iterrows():
             color = "purple"
             axes.plot(
@@ -1307,7 +1300,6 @@ def plot_mask_cell_track_2D3Dstatic(
     )
     time_cell = time[slice(i_start, i_end)]
     for time_i in time_cell:
-
         #    for i_row,row in track_cell.iterrows():
         #        time_i=row['time']
         #        constraint_time = Constraint(time=row['time'])
@@ -1485,7 +1477,6 @@ def plot_mask_cell_track_3Dstatic(
     )
     time_cell = time[slice(i_start, i_end)]
     for time_i in time_cell:
-
         #    for i_row,row in track_cell.iterrows():
         #        time_i=row['time']
         #        constraint_time = Constraint(time=row['time'])
@@ -1857,7 +1848,6 @@ def plot_mask_cell_track_static_timeseries(
     )
     time_cell = time[slice(i_start, i_end)]
     for time_i in time_cell:
-
         constraint_time = Constraint(time=time_i)
         constraint_x = Constraint(
             projection_x_coordinate=lambda cell: x_min < cell < x_max

--- a/tobac/wrapper.py
+++ b/tobac/wrapper.py
@@ -12,7 +12,6 @@ def tracking_wrapper(
     parameters_tracking=None,
     parameters_segmentation=None,
 ):
-
     from .feature_detection import feature_detection_multithreshold
     from .tracking import linking_trackpy
     from .segmentation import segmentation_3D, segmentation_2D


### PR DESCRIPTION
`setup.py` now finds required packages by parsing `requirements.txt`, rather than having to maintain the list of packages in both

I've also added two new requirements files -- `dev_requirements.txt` and `example_requirements.txt` that contain the additional dependencies for developers and for running the example notebooks respectively.

The `check_formatting` action previously used `pip` to install requirements, however this broke when trying to install `cartopy`. I've changed it to use `conda` instead, in the same manner as the `codecov-CI` action

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [x] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [x] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [x] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

