### PR TITLE
Fix to readthedocs builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,4 +4,3 @@ python:
   version: 3
   install:
     - requirements: doc/requirements.txt
-  system_packages: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Tobac Changelog
 
+_**Version 1.5.1:**_
+
+**Bug fixes**
+
+- Fix to readthedocs building after system packages no longer imported [#336](https://github.com/tobac-project/tobac/pull/336)
+
+
 _**Version 1.5.0:**_
 
 **Enhancements for Users**


### PR DESCRIPTION
Resolves an issue with readthedocs builds discovered with #335. 

We, incidentally, talked about this today. See: https://blog.readthedocs.com/drop-support-system-packages/ . While we had to deal with some of the consequences of this earlier, we now have the new issue of `system_packages: true` in our readthedocs config, breaking readthedocs builds. This PR should alleviate that issue.

In my mind, this is now a blocking PR, and 1.5.1 shouldn't be released until this is merged or the issue is resolved in some other way.

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [ ] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [ ] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

