### PR TITLE
Fix for Jupyter Notebook CI

### DIFF
--- a/.github/workflows/check_notebooks.yml
+++ b/.github/workflows/check_notebooks.yml
@@ -12,13 +12,19 @@ jobs:
       - name: set up conda environment
         uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-version: latest
+          miniforge-variant: mambaforge
+          channel-priority: strict
+          channels: conda-forge
+          show-channel-urls: true
+          use-only-tar-bz2: true
           auto-update-conda: true
           auto-activate-base: false
           activate-environment: notebook-env
       - name: Install tobac dependencies
         run: |
-          conda install -c conda-forge --yes ffmpeg gcc jupyter pytables
-          conda install -c conda-forge --yes --file example_requirements.txt
+          mamba install -c conda-forge --yes ffmpeg gcc jupyter pytables
+          mamba install -c conda-forge --yes --file example_requirements.txt
       - name: Install tobac
         run: |
           pip install .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _**Version 1.5.1:**_
 
 - Fix to readthedocs building after system packages no longer imported [#336](https://github.com/tobac-project/tobac/pull/336)
 - The `strict_thresholding` option in feature detection now works correctly for detecting minima, and produces the same results as without strict thresholding if the `n_min_threshold` is a scalar value [#316](https://github.com/tobac-project/tobac/pull/316)
+
+**Repository Enhancements**
 - Fix to Jupyter Notebook CI that was timing out due to installing packages with `conda`, switched to `mamba` to resolve. [#340](https://github.com/tobac-project/tobac/pull/340)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _**Version 1.5.1:**_
 
 - Fix to readthedocs building after system packages no longer imported [#336](https://github.com/tobac-project/tobac/pull/336)
 - The `strict_thresholding` option in feature detection now works correctly for detecting minima, and produces the same results as without strict thresholding if the `n_min_threshold` is a scalar value [#316](https://github.com/tobac-project/tobac/pull/316)
+- Fix to Jupyter Notebook CI that was timing out due to installing packages with `conda`, switched to `mamba` to resolve. [#340](https://github.com/tobac-project/tobac/pull/340)
 
 
 _**Version 1.5.0:**_

--- a/example_requirements.txt
+++ b/example_requirements.txt
@@ -14,3 +14,4 @@ notebook
 pytables
 s3fs
 arm_pyart
+h5netcdf


### PR DESCRIPTION
Resolves #339 and fixes our Jupyter Notebook CI by switching the dependency installer to `mamba` from `conda`. Also fixed a bug with our requirements that did not explicitly require `h5netcdf` which is required for the example that uses s3 to work. 

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [ ] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

