### PR TITLE
fixed duplicate index issue in test_trackpy_predict

### DIFF
--- a/tobac/tests/test_tracking.py
+++ b/tobac/tests/test_tracking.py
@@ -449,8 +449,10 @@ def test_trackpy_predict():
     cell_2_expected = copy.deepcopy(cell_2)
     cell_2_expected["cell"] = np.int32(2)
 
-    features = pd.concat([cell_1, cell_2])
-    expected_output = pd.concat([cell_1_expected, cell_2_expected])
+    features = pd.concat([cell_1, cell_2], ignore_index=True, verify_integrity=True)
+    expected_output = pd.concat(
+        [cell_1_expected, cell_2_expected], ignore_index=True, verify_integrity=True
+    )
 
     output = tobac.linking_trackpy(
         features, None, 1, 1, d_max=100, method_linking="predict"


### PR DESCRIPTION
Fixes issue related to non-unique index values in dataframes for testing.
Solves #342 

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [ ] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [x] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

