### PR TITLE
Pbc feature location fix

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,9 @@
 version: 2
 formats: all
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
 python:
-  version: 3
   install:
     - requirements: doc/requirements.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
 ipykernel
 nbsphinx
 numpy
+sphinx_rtd_theme

--- a/tobac/segmentation.py
+++ b/tobac/segmentation.py
@@ -786,7 +786,7 @@ def segmentation_timestep(
                 if buddy == 0:
                     continue
                 # isolate feature from set of buddies
-                buddy_feat = features_in[features_in["feature"] == buddy]
+                buddy_feat = features_in[features_in["feature"] == buddy].iloc[0]
 
                 # transform buddy feature position if needed for positioning in z2/y2/x2 space
                 # MAY be redundant with what is done just below here

--- a/tobac/segmentation.py
+++ b/tobac/segmentation.py
@@ -104,8 +104,9 @@ def add_markers(
         marker_arr = marker_arr[np.newaxis, :, :]
 
     if seed_3D_flag == "column":
-        for index, row in features.iterrows():
-            marker_arr[level, int(row["hdim_1"]), int(row["hdim_2"])] = row["feature"]
+        for _, row in features.iterrows():
+            # Offset marker locations by 0.5 to find nearest pixel
+            marker_arr[level, int(row["hdim_1"]+0.5) % h1_len, int(row["hdim_2"]+0.5) % h2_len] = row["feature"]
 
     elif seed_3D_flag == "box":
         # Get the size of the seed box from the input parameter
@@ -123,7 +124,7 @@ def add_markers(
             seed_h1 = seed_3D_size
             seed_h2 = seed_3D_size
 
-        for index, row in features.iterrows():
+        for _, row in features.iterrows():
             if is_3D:
                 # If we have a 3D input and we need to do box seeding
                 # we need to have 3D features.

--- a/tobac/segmentation.py
+++ b/tobac/segmentation.py
@@ -106,7 +106,11 @@ def add_markers(
     if seed_3D_flag == "column":
         for _, row in features.iterrows():
             # Offset marker locations by 0.5 to find nearest pixel
-            marker_arr[level, int(row["hdim_1"]+0.5) % h1_len, int(row["hdim_2"]+0.5) % h2_len] = row["feature"]
+            marker_arr[
+                level,
+                int(row["hdim_1"] + 0.5) % h1_len,
+                int(row["hdim_2"] + 0.5) % h2_len,
+            ] = row["feature"]
 
     elif seed_3D_flag == "box":
         # Get the size of the seed box from the input parameter

--- a/tobac/utils/periodic_boundaries.py
+++ b/tobac/utils/periodic_boundaries.py
@@ -297,7 +297,10 @@ def weighted_circmean(
         angle_average = np.arctan2(sin_average, cos_average) % (2 * np.pi)
     rescaled_average = (angle_average * scaling_factor) + low
     # Round return value to try and supress rounding errors
-    return np.round(rescaled_average, 12)
+    rescaled_average = np.round(rescaled_average, 12)
+    if rescaled_average == high:
+        rescaled_average = low
+    return rescaled_average
 
 
 def transfm_pbc_point(in_dim, dim_min, dim_max):


### PR DESCRIPTION
Fixes out-of-bounds error in segmentation due to PBC features in #349 

I also changed the location where 'column' seeding places the marker. Previously it took the floor of the array index, but now it goes to the nearest index. This may change the results of segmentation, so I can revert it if it is an issue

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [x] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [x] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [x] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

