### PR TITLE
Add Pylint to Workflow

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,69 @@
+name: Linting
+on:
+  pull_request:
+    branches:
+      - '*'
+permissions:
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+
+      - name: Store the PR branch
+        run: |
+          echo "SHA=$(git rev-parse "$GITHUB_SHA")" >> $GITHUB_OUTPUT
+        id: git
+
+      - name: Switch to main branch
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: Install tobac and pylint 
+        run: |
+          pip install .
+          pip install --upgrade pylint
+      - name: Get pylint score of main branch
+        run: |
+          pylint tobac --disable=C --exit-zero
+        id: main_score
+
+      - name: Switch to PR branch
+        uses: actions/checkout@v3
+        with:
+          ref: "${{ steps.git.outputs.SHA}}"  
+
+      - name: Get pylint score of PR branch
+        run: |
+          # use shell script to save only tail of output  
+          OUTPUT_PART=$(pylint tobac --disable=C | tail -n 2)
+          # but post entire output in the action details 
+          pylint tobac --disable=C --exit-zero
+          # define random delimiter for multiline string
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "MESSAGE<<$EOF" >> "$GITHUB_OUTPUT"
+          echo "$OUTPUT_PART" >> "$GITHUB_OUTPUT"
+          echo "$EOF" >> "$GITHUB_OUTPUT"
+        id: pr_score
+
+      - name: Post result to PR
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            Linting results by Pylint:
+            --------------------------
+            ${{ steps.pr_score.outputs.MESSAGE}}
+            <sub>The linting score is an indicator that reflects how well your code version follows Pylint’s coding standards and quality metrics with respect to the main branch.
+            A decrease usually indicates your new code does not fully meet style guidelines or has potential errors.<sup>
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub token
+          allow-repeats: false # This is the default

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -23,21 +23,31 @@ jobs:
           echo "SHA=$(git rev-parse "$GITHUB_SHA")" >> $GITHUB_OUTPUT
         id: git
 
-      - name: Switch to main branch
+      - name: Get RC branch name
+        run: |
+          git fetch --all
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "RC_BRANCH<<$EOF" >> $GITHUB_OUTPUT
+          echo "$(git branch -r --list 'origin/RC*' --sort=-committerdate | head -n 1 | sed 's/origin\///' | xargs)" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+        id: branch_name
+
+      - name: Checkout RC branch
         uses: actions/checkout@v3
         with:
-          ref: main
+          ref: ${{ steps.branch_name.outputs.RC_BRANCH }}
 
       - name: Install tobac and pylint 
         run: |
           pip install .
           pip install --upgrade pylint
-      - name: Get pylint score of main branch
+          
+      - name: Get pylint score of RC branch
         run: |
           pylint tobac --disable=C --exit-zero
         id: main_score
 
-      - name: Switch to PR branch
+      - name: Checkout PR branch
         uses: actions/checkout@v3
         with:
           ref: "${{ steps.git.outputs.SHA}}"  
@@ -62,7 +72,7 @@ jobs:
             Linting results by Pylint:
             --------------------------
             ${{ steps.pr_score.outputs.MESSAGE}}
-            <sub>The linting score is an indicator that reflects how well your code version follows Pylint’s coding standards and quality metrics with respect to the main branch.
+            <sub>The linting score is an indicator that reflects how well your code version follows Pylint’s coding standards and quality metrics with respect to the ${{ steps.branch_name.outputs.RC_BRANCH}} branch.
             A decrease usually indicates your new code does not fully meet style guidelines or has potential errors.<sup>
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub token

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -36,19 +36,10 @@ jobs:
           echo "SHA=$(git rev-parse "$GITHUB_SHA")" >> $GITHUB_OUTPUT
         id: git
 
-      - name: Get RC branch name
-        run: |
-          git fetch --all
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "RC_BRANCH<<$EOF" >> $GITHUB_OUTPUT
-          echo "$(git branch -r --list 'origin/RC*' --sort=-committerdate | head -n 1 | sed 's/origin\///' | xargs)" >> $GITHUB_OUTPUT
-          echo "$EOF" >> $GITHUB_OUTPUT
-        id: branch_name
-
       - name: Checkout RC branch
         uses: actions/checkout@v3
         with:
-          ref: ${{ steps.branch_name.outputs.RC_BRANCH }}
+          ref: ${{ github.base_ref }}
           
       - name: Get pylint score of RC branch
         run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -64,15 +64,23 @@ jobs:
           echo "$EOF" >> "$GITHUB_OUTPUT"
         id: pr_score
 
-      - name: Post result to PR
-        uses: mshick/add-pr-comment@v1
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: comment
         with:
-          message: |
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Linting results by Pylint
+
+      - name: Post result to PR
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
             Linting results by Pylint:
             --------------------------
             ${{ steps.pr_score.outputs.MESSAGE }}
-            <sub>The linting score is an indicator that reflects how well your code version follows Pylint’s coding standards and quality metrics with respect to the ${{ steps.branch_name.outputs.RC_BRANCH }} branch.
+            <sub>The linting score is an indicator that reflects how well your code version follows Pylint’s coding standards and quality metrics with respect to the ${{ github.base_ref }} branch.
             A decrease usually indicates your new code does not fully meet style guidelines or has potential errors.<sup>
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub token
-          allow-repeats: false # This is the default

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,14 +9,27 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v3
+      - name: Set up conda
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: '3.9'
+          miniforge-version: latest
+          miniforge-variant: mambaforge
+          channel-priority: strict
+          channels: conda-forge
+          show-channel-urls: true
+          use-only-tar-bz2: true
+
+      - name: Install tobac and pylint
+        run: |
+          mamba install --yes pylint
+          pip install .
 
       - name: Store the PR branch
         run: |
@@ -36,11 +49,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.branch_name.outputs.RC_BRANCH }}
-
-      - name: Install tobac and pylint 
-        run: |
-          pip install .
-          pip install --upgrade pylint
           
       - name: Get pylint score of RC branch
         run: |
@@ -50,12 +58,12 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v3
         with:
-          ref: "${{ steps.git.outputs.SHA}}"  
+          ref: "${{ steps.git.outputs.SHA }}"  
 
       - name: Get pylint score of PR branch
         run: |
           # use shell script to save only tail of output  
-          OUTPUT_PART=$(pylint tobac --disable=C | tail -n 2)
+          OUTPUT_PART=$(pylint tobac --disable=C --exit-zero | tail -n 2)
           # but post entire output in the action details 
           pylint tobac --disable=C --exit-zero
           # define random delimiter for multiline string
@@ -71,8 +79,8 @@ jobs:
           message: |
             Linting results by Pylint:
             --------------------------
-            ${{ steps.pr_score.outputs.MESSAGE}}
-            <sub>The linting score is an indicator that reflects how well your code version follows Pylint’s coding standards and quality metrics with respect to the ${{ steps.branch_name.outputs.RC_BRANCH}} branch.
+            ${{ steps.pr_score.outputs.MESSAGE }}
+            <sub>The linting score is an indicator that reflects how well your code version follows Pylint’s coding standards and quality metrics with respect to the ${{ steps.branch_name.outputs.RC_BRANCH }} branch.
             A decrease usually indicates your new code does not fully meet style guidelines or has potential errors.<sup>
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub token


### PR DESCRIPTION
This is testing a theory, and is entirely copied from #278 . Per the GitHub documentation (https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token), the Pylint runner will never work on Julia's fork (and in #278) as the maximum access for PRs from public forked repos is read. In theory, this, which copies over the changes from #278 to a branch within our repo, *should* work. 

* [ ] Have you followed our guidelines in CONTRIBUTING.md? 
* [ ] Have you self-reviewed your code and corrected any misspellings? 
* [ ] Have you written documentation that is easy to understand?
* [ ] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [ ] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [ ] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [ ] Have you kept your pull request small and limited so that it is easy to review? 
* [ ] Have the newest changes from this branch been merged? 

