### PR TITLE
Bugfix in grid spacing

### DIFF
--- a/tobac/utils/general.py
+++ b/tobac/utils/general.py
@@ -431,7 +431,6 @@ def get_spacings(
         if average_method == "arithmetic":
             dxy = 0.5 * (np.abs(dx) + np.abs(dy))
         elif average_method == "geometric":
-            # I would prefer a geometric mean
             dxy = np.sqrt(np.abs(dx) * np.abs(dy))
 
     elif grid_spacing is not None:
@@ -452,6 +451,10 @@ def get_spacings(
     elif time_spacing is not None:
         # use value of time_spacing for dt:
         dt = time_spacing
+    else:
+        raise ValueError(
+            "no information about time spacing, need either input cube with time or keyword argument time_spacing"
+        )
     return dxy, dt
 
 

--- a/tobac/utils/general.py
+++ b/tobac/utils/general.py
@@ -367,7 +367,7 @@ def get_bounding_box(x, buffer=1):
 
 
 def get_spacings(
-    field_in, grid_spacing=None, time_spacing=None, average_type="arithmetic"
+    field_in, grid_spacing=None, time_spacing=None, average_method="arithmetic"
 ):
     """Determine spatial and temporal grid spacing of the
     input data.
@@ -385,7 +385,7 @@ def get_spacings(
         Manually sets the time spacing if specified.
         Default is None.
 
-    average_type : string, optional
+    average_method : string, optional
         Defines how spacings in x- and y-direction are
         combined.
 
@@ -423,14 +423,14 @@ def get_spacings(
     ) and (grid_spacing is None):
         x_coord = deepcopy(field_in.coord("projection_x_coordinate"))
         x_coord.convert_units("metre")
-        dx = np.diff(field_in.coord("projection_y_coordinate")[0:2].points)[0]
+        dx = np.diff(x_coord[0:2].points)[0]
         y_coord = deepcopy(field_in.coord("projection_y_coordinate"))
         y_coord.convert_units("metre")
-        dy = np.diff(field_in.coord("projection_y_coordinate")[0:2].points)[0]
+        dy = np.diff(y_coord[0:2].points)[0]
 
-        if average_type == "arithmetic":
+        if average_method == "arithmetic":
             dxy = 0.5 * (np.abs(dx) + np.abs(dy))
-        elif average_type == "geometric":
+        elif average_method == "geometric":
             # I would prefer a geometric mean
             dxy = np.sqrt(np.abs(dx) * np.abs(dy))
 

--- a/tobac/utils/general.py
+++ b/tobac/utils/general.py
@@ -366,7 +366,6 @@ def get_bounding_box(x, buffer=1):
     return bbox
 
 
-@internal_utils.xarray_to_iris
 def get_spacings(
     field_in, grid_spacing=None, time_spacing=None, average_type="arithmetic"
 ):


### PR DESCRIPTION
## Description
I found a bug in the get_spacing functionality and fixed it.

*Problem:* If x is storing in ascending and y in descending order (and vice versa), than the grid spacing increment subtract eachother - which is not wanted. 

*Solution:* used the absolute value

*Extension:* 
- also added a new keyword `average_type` to allow to switch between averaging strategies
- implemented geometric mean which more appropriate in my view

## Checklist
* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [x] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] **Have you kept your pull request small and limited so that it is easy to review?** 
* [x] Have the newest changes from this branch been merged? 

Cheers, Fabian.

PS: should be very easy to review and merge back

