### PR TITLE
Fix floating point error in 2d/3d coordinate interpolation

### DIFF
--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -18,7 +18,7 @@ References
 """
 
 from __future__ import annotations
-from typing import Union, Callable
+from typing import Optional, Union, Callable
 import warnings
 import logging
 
@@ -1143,10 +1143,10 @@ def feature_detection_multithreshold(
     min_distance: float = 0,
     feature_number_start: int = 1,
     PBC_flag: Literal["none", "hdim_1", "hdim_2", "both"] = "none",
-    vertical_coord: str = None,
-    vertical_axis: int = None,
-    detect_subset: dict = None,
-    wavelength_filtering: tuple = None,
+    vertical_coord: Optional[str] = None,
+    vertical_axis: Optional[int] = None,
+    detect_subset: Optional[dict] = None,
+    wavelength_filtering: Optional[tuple] = None,
     dz: Union[float, None] = None,
     strict_thresholding: bool = False,
     statistic: Union[dict[str, Union[Callable, tuple[Callable, dict]]], None] = None,

--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -199,8 +199,8 @@ def feature_position(
 
     elif position_threshold == "weighted_diff":
         # get position as centre of identified region, weighted by difference from the threshold:
-        weights = abs(track_data_region[region_small] - threshold_i)
-        if sum(weights) == 0:
+        weights = np.abs(track_data_region[region_small] - threshold_i)
+        if np.sum(weights) == 0:
             weights = None
         hdim1_weights = weights
         hdim2_weights = weights
@@ -211,8 +211,8 @@ def feature_position(
 
     elif position_threshold == "weighted_abs":
         # get position as centre of identified region, weighted by absolute values if the field:
-        weights = abs(track_data_region[region_small])
-        if sum(weights) == 0:
+        weights = np.abs(track_data_region[region_small])
+        if np.sum(weights) == 0:
             weights = None
         hdim1_weights = weights
         hdim2_weights = weights
@@ -230,14 +230,18 @@ def feature_position(
             hdim1_index = pbc_utils.weighted_circmean(
                 hdim1_indices, weights=hdim1_weights, high=hdim1_max + 1, low=hdim1_min
             )
+            hdim1_index = np.clip(hdim1_index, 0, hdim1_max + 1)
         else:
             hdim1_index = np.average(hdim1_indices, weights=hdim1_weights)
+            hdim1_index = np.clip(hdim1_index, 0, hdim1_max)
         if PBC_flag in ("hdim_2", "both"):
             hdim2_index = pbc_utils.weighted_circmean(
                 hdim2_indices, weights=hdim2_weights, high=hdim2_max + 1, low=hdim2_min
             )
+            hdim2_index = np.clip(hdim2_index, 0, hdim2_max + 1)
         else:
             hdim2_index = np.average(hdim2_indices, weights=hdim2_weights)
+            hdim2_index = np.clip(hdim2_index, 0, hdim2_max)
         if is_3D:
             vdim_index = np.average(vdim_indices, weights=vdim_weights)
 

--- a/tobac/utils/general.py
+++ b/tobac/utils/general.py
@@ -19,7 +19,8 @@ import warnings
 
 
 def add_coordinates(
-    features : pd.DataFrame, variable_cube: iris.cube.Cube, 
+    features: pd.DataFrame,
+    variable_cube: iris.cube.Cube,
 ):
     """Add coordinates from the input cube of the feature detection
     to the trajectories/features.

--- a/tobac/utils/general.py
+++ b/tobac/utils/general.py
@@ -35,9 +35,6 @@ def add_coordinates(
         to transfer to the resulting DataFrame. Needs to contain the
         coordinate 'time'.
 
-    PBC_flag : Literal["none", "hdim_1", "hdim_2", "both"]
-        Periodic boundary condition flag
-
     Returns
     -------
     pandas.DataFrame


### PR DESCRIPTION
Resolves #433. Clipping of hdim1/2 values to size of dimensions (or size + 1 for periodic coordinates) in `feature_location`, and extrapolation enabled for 2d/3d coordinates as with 1d coords.

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [x] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

