### PR TITLE
Fix minimum distance filtering for varying vertical coordinates

### DIFF
--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -627,9 +627,9 @@ def feature_detection_threshold(
                         # find the updated label, and overwrite all of label_ind indices with
                         # updated label
                         labels_2_alt = labels_2[label_z, y_val_alt, x_val_alt]
-                        labels_2[
-                            label_locs_v, label_locs_h1, label_locs_h2
-                        ] = labels_2_alt
+                        labels_2[label_locs_v, label_locs_h1, label_locs_h2] = (
+                            labels_2_alt
+                        )
                         skip_list = np.append(skip_list, label_ind)
                         break
 
@@ -673,9 +673,9 @@ def feature_detection_threshold(
                         # find the updated label, and overwrite all of label_ind indices with
                         # updated label
                         labels_2_alt = labels_2[label_z, y_val_alt, label_x]
-                        labels_2[
-                            label_locs_v, label_locs_h1, label_locs_h2
-                        ] = labels_2_alt
+                        labels_2[label_locs_v, label_locs_h1, label_locs_h2] = (
+                            labels_2_alt
+                        )
                         new_label_ind = labels_2_alt
                         skip_list = np.append(skip_list, label_ind)
 
@@ -717,9 +717,9 @@ def feature_detection_threshold(
                         # find the updated label, and overwrite all of label_ind indices with
                         # updated label
                         labels_2_alt = labels_2[label_z, label_y, x_val_alt]
-                        labels_2[
-                            label_locs_v, label_locs_h1, label_locs_h2
-                        ] = labels_2_alt
+                        labels_2[label_locs_v, label_locs_h1, label_locs_h2] = (
+                            labels_2_alt
+                        )
                         new_label_ind = labels_2_alt
                         skip_list = np.append(skip_list, label_ind)
 
@@ -1115,7 +1115,7 @@ def feature_detection_multithreshold_timestep(
             + " : "
             + str(threshold_i)
         )
-    
+
     if statistic:
         # reconstruct the labeled regions based on the regions dict
         labels = np.zeros(track_data.shape)
@@ -1132,7 +1132,7 @@ def feature_detection_multithreshold_timestep(
             index=np.unique(labels[labels > 0]),
             id_column="idx",
         )
-    
+
     return features_thresholds
 
 
@@ -1276,7 +1276,7 @@ def feature_detection_multithreshold(
 
     # Remember if dz is set and not vertical coord for min distance filtering
     use_dz_for_filtering = dz is not None
-        
+
     if is_3D:
         # We need to determine the time axis so that we can determine the
         # vertical axis in each timestep if vertical_axis is not none.
@@ -1375,7 +1375,7 @@ def feature_detection_multithreshold(
             strict_thresholding=strict_thresholding,
             statistic=statistic,
         )
-        
+
         list_features_timesteps.append(features_thresholds)
 
         logging.debug(
@@ -1397,7 +1397,7 @@ def feature_detection_multithreshold(
             )
         else:
             features = add_coordinates(features, field_in)
-        
+
         # Loop over DataFrame to remove features that are closer than distance_min to each
         # other:
         filtered_features = []
@@ -1412,10 +1412,12 @@ def feature_detection_multithreshold(
                 filtered_features.append(
                     filter_min_distance(
                         features_frame,
-                        dxy = dxy,
-                        dz = dz if use_dz_for_filtering else None,
-                        min_distance = min_distance,
-                        z_coordinate_name = None if use_dz_for_filtering else vertical_coord,
+                        dxy=dxy,
+                        dz=dz if use_dz_for_filtering else None,
+                        min_distance=min_distance,
+                        z_coordinate_name=(
+                            None if use_dz_for_filtering else vertical_coord
+                        ),
                         target=target,
                         PBC_flag=PBC_flag,
                         min_h1=0,
@@ -1505,9 +1507,7 @@ def filter_min_distance(
 
     # Check if both dxy and their coordinate names are specified.
     # If they are, warn that we will use dxy.
-    elif (
-        x_coordinate_name in features and y_coordinate_name in features
-    ):
+    elif x_coordinate_name in features and y_coordinate_name in features:
         warnings.warn(
             "Both " + x_coordinate_name + "/" + y_coordinate_name + " and dxy "
             "set. Using constant dxy. Set dxy to None if you want to use the "
@@ -1538,11 +1538,11 @@ def filter_min_distance(
                     + z_coordinate_name
                     + " and dz available to filter_min_distance; using constant dz. "
                     "Set dz to none if you want to use altitude or set `z_coordinate_name` to None to use "
-                    "constant dz.", 
-                    UserWarning, 
+                    "constant dz.",
+                    UserWarning,
                 )
             z_coordinate_name = "vdim"
-    
+
     if target not in ["minimum", "maximum"]:
         raise ValueError(
             "target parameter must be set to either 'minimum' or 'maximum'"

--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -1527,7 +1527,7 @@ def filter_min_distance(
         if dz is None:
             # Find vertical coord name and set dz to 1
             z_coordinate_name = internal_utils.find_dataframe_vertical_coord(
-                variable_dataframe=tracks, vertical_coord=z_coordinate_name
+                variable_dataframe=features, vertical_coord=z_coordinate_name
             )
             dz = 1
         else:

--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -627,9 +627,9 @@ def feature_detection_threshold(
                         # find the updated label, and overwrite all of label_ind indices with
                         # updated label
                         labels_2_alt = labels_2[label_z, y_val_alt, x_val_alt]
-                        labels_2[label_locs_v, label_locs_h1, label_locs_h2] = (
-                            labels_2_alt
-                        )
+                        labels_2[
+                            label_locs_v, label_locs_h1, label_locs_h2
+                        ] = labels_2_alt
                         skip_list = np.append(skip_list, label_ind)
                         break
 
@@ -673,9 +673,9 @@ def feature_detection_threshold(
                         # find the updated label, and overwrite all of label_ind indices with
                         # updated label
                         labels_2_alt = labels_2[label_z, y_val_alt, label_x]
-                        labels_2[label_locs_v, label_locs_h1, label_locs_h2] = (
-                            labels_2_alt
-                        )
+                        labels_2[
+                            label_locs_v, label_locs_h1, label_locs_h2
+                        ] = labels_2_alt
                         new_label_ind = labels_2_alt
                         skip_list = np.append(skip_list, label_ind)
 
@@ -717,9 +717,9 @@ def feature_detection_threshold(
                         # find the updated label, and overwrite all of label_ind indices with
                         # updated label
                         labels_2_alt = labels_2[label_z, label_y, x_val_alt]
-                        labels_2[label_locs_v, label_locs_h1, label_locs_h2] = (
-                            labels_2_alt
-                        )
+                        labels_2[
+                            label_locs_v, label_locs_h1, label_locs_h2
+                        ] = labels_2_alt
                         new_label_ind = labels_2_alt
                         skip_list = np.append(skip_list, label_ind)
 

--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -1109,29 +1109,30 @@ def feature_detection_multithreshold_timestep(
         elif i_threshold == 0:
             regions_old = regions_i
 
-        if statistic:
-            # reconstruct the labeled regions based on the regions dict
-            labels = np.zeros(track_data.shape)
-            labels = labels.astype(int)
-            for key in regions_old.keys():
-                labels.ravel()[regions_old[key]] = key
-                # apply function to get statistics based on labeled regions and functions provided by the user
-                # the feature dataframe is updated by appending a column for each metric
-            features_thresholds = get_statistics(
-                features_thresholds,
-                labels,
-                track_data,
-                statistic=statistic,
-                index=np.unique(labels[labels > 0]),
-                id_column="idx",
-            )
-
         logging.debug(
             "Finished feature detection for threshold "
             + str(i_threshold)
             + " : "
             + str(threshold_i)
         )
+    
+    if statistic:
+        # reconstruct the labeled regions based on the regions dict
+        labels = np.zeros(track_data.shape)
+        labels = labels.astype(int)
+        for key in regions_old.keys():
+            labels.ravel()[regions_old[key]] = key
+            # apply function to get statistics based on labeled regions and functions provided by the user
+            # the feature dataframe is updated by appending a column for each metric
+        features_thresholds = get_statistics(
+            features_thresholds,
+            labels,
+            track_data,
+            statistic=statistic,
+            index=np.unique(labels[labels > 0]),
+            id_column="idx",
+        )
+    
     return features_thresholds
 
 

--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -1136,10 +1136,14 @@ def feature_detection_multithreshold_timestep(
             labels.ravel()[regions_old[key]] = key
             # apply function to get statistics based on labeled regions and functions provided by the user
             # the feature dataframe is updated by appending a column for each metric
+        
+        # select which data to use according to statistics_unsmoothed option
+        stats_data = data_i.core_data() if statistics_unsmoothed else track_data
+        
         features_thresholds = get_statistics(
             features_thresholds,
             labels,
-            track_data,
+            stats_data, 
             statistic=statistic,
             index=np.unique(labels[labels > 0]),
             id_column="idx",

--- a/tobac/tests/test_feature_detection.py
+++ b/tobac/tests/test_feature_detection.py
@@ -319,6 +319,34 @@ def test_feature_detection_position(position_threshold):
             True,
             False,
         ),
+        (  # Test using z coord name
+            (0, 0, 0, 4, 1),
+            (1, 1, 1, 4, 1),
+            1000,
+            None,
+            1,
+            "maximum",
+            False,
+            False,
+            True,
+            "none",
+            True,
+            True,
+        ),
+        (  # Test using z coord name
+            (0, 0, 0, 5, 1),
+            (1, 1, 1, 4, 1),
+            1,
+            None,
+            101,
+            "maximum",
+            False,
+            False,
+            True,
+            "none",
+            True,
+            False,
+        ),
     ],
 )
 def test_filter_min_distance(
@@ -415,18 +443,6 @@ def test_filter_min_distance(
 
     feat_combined = pd.concat([feat_1_interp, feat_2_interp], ignore_index=True)
 
-    filter_dist_opts = dict()
-
-    if add_x_coords:
-        feat_combined[x_coord_name] = feat_combined["hdim_2"] * assumed_dxy
-        filter_dist_opts["x_coordinate_name"] = x_coord_name
-    if add_y_coords:
-        feat_combined[y_coord_name] = feat_combined["hdim_1"] * assumed_dxy
-        filter_dist_opts["y_coordinate_name"] = y_coord_name
-    if add_z_coords and is_3D:
-        feat_combined[z_coord_name] = feat_combined["vdim"] * assumed_dz
-        filter_dist_opts["z_coordinate_name"] = z_coord_name
-
     filter_dist_opts = {
         "features": feat_combined,
         "dxy": dxy,
@@ -439,6 +455,16 @@ def test_filter_min_distance(
         "min_h2": 0,
         "max_h2": 100,
     }
+    if add_x_coords:
+        feat_combined[x_coord_name] = feat_combined["hdim_2"] * assumed_dxy
+        filter_dist_opts["x_coordinate_name"] = x_coord_name
+    if add_y_coords:
+        feat_combined[y_coord_name] = feat_combined["hdim_1"] * assumed_dxy
+        filter_dist_opts["y_coordinate_name"] = y_coord_name
+    if add_z_coords and is_3D:
+        feat_combined[z_coord_name] = feat_combined["vdim"] * assumed_dz
+        filter_dist_opts["z_coordinate_name"] = z_coord_name
+
     if target not in ["maximum", "minimum"]:
         with pytest.raises(ValueError):
             out_feats = feat_detect.filter_min_distance(**filter_dist_opts)


### PR DESCRIPTION
Resolves #430 and #413

The order of coordinate interpolation and minimum distance filtering has been swapped, so that the z coordinate can be used for finding the spacing of features rather than assuming a fixed vertical grid spacing. The `filter_min_distance` has also been fixed so that the provided z coordinate will be used, rather than always using `dz`. Incidentally, another bug was fixed in `feature_detection_multithreshold_timestep` was fixed, in which statistics were being recalculated at each threshold value, rather than once at the end.

Ideally, I would like to move adding coordinates and distance filtering inside `feature_detection_multithreshold_timestep`, but at the moment we are not passing through the required info to do this. As the feature detection code is in need of refactoring, I'll leave this until after v1.6 to avoid conflicts with the switch to xarray

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [x] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [x] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [x] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

