### PR TITLE
Fix CI issues due to old conda version

### DIFF
--- a/.github/workflows/check_notebooks.yml
+++ b/.github/workflows/check_notebooks.yml
@@ -9,22 +9,13 @@ jobs:
     steps:
       - name: check out repository code
         uses: actions/checkout@v3
-      - name: set up conda environment
-        uses: conda-incubator/setup-miniconda@v2
+      - name: set up mamba environment
+        uses: mamba-org/setup-micromamba@v1
         with:
-          miniforge-version: latest
-          miniforge-variant: mambaforge
-          channel-priority: strict
-          channels: conda-forge
-          show-channel-urls: true
-          use-only-tar-bz2: true
-          auto-update-conda: true
-          auto-activate-base: false
-          activate-environment: notebook-env
-      - name: Install tobac dependencies
-        run: |
-          mamba install -c conda-forge --yes ffmpeg gcc jupyter pytables
-          mamba install -c conda-forge --yes --file example_requirements.txt
+          environment-file: environment-examples.yml
+          generate-run-shell: true
+          cache-environment: true
+          cache-downloads: true
       - name: Install tobac
         run: |
           pip install .

--- a/.github/workflows/codecov-CI.yml
+++ b/.github/workflows/codecov-CI.yml
@@ -7,24 +7,20 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OS: ubuntu-latest
-      PYTHON: "3.9"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Similar to MetPy install-conda action
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: mamba-org/setup-micromamba@v1
         with:
-          miniforge-version: latest
-          miniforge-variant: mambaforge
-          channel-priority: strict
-          channels: conda-forge
-          show-channel-urls: true
-          use-only-tar-bz2: true
+          environment-file: environment-ci.yml
+          generate-run-shell: true
+          cache-environment: true
+          cache-downloads: true
 
-      - name: Install dependencies and generate report
-        shell: bash -l {0}
+      - name: Generate report
+        shell: micromamba-shell {0}
         run:
-          mamba install --quiet --yes --file requirements.txt coverage pytest-cov &&
           python -m coverage run -m pytest --cov=./ --cov-report=xml
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,29 +7,27 @@ permissions:
   pull-requests: write
 
 jobs:
-  build:
+  lint-workflow:
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
-
-      - name: Set up mamba
+        uses: actions/checkout@v4
+      - name: Set up mamba environment
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment-ci.yml
           generate-run-shell: true
           cache-environment: true
           cache-downloads: true
-
       - name: Install tobac
-        run: |
+        run:
           pip install .
 
       - name: Store the PR branch
-        run: |
+        run:
           echo "SHA=$(git rev-parse "$GITHUB_SHA")" >> $GITHUB_OUTPUT
         id: git
 
@@ -39,7 +37,7 @@ jobs:
           ref: ${{ github.base_ref }}
           
       - name: Get pylint score of RC branch
-        run: |
+        run:
           pylint tobac --disable=C --exit-zero
         id: main_score
 
@@ -49,7 +47,7 @@ jobs:
           ref: "${{ steps.git.outputs.SHA }}"  
 
       - name: Get pylint score of PR branch
-        run: |
+        run:
           # use shell script to save only tail of output  
           OUTPUT_PART=$(pylint tobac --disable=C --exit-zero | tail -n 2)
           # but post entire output in the action details 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,21 +14,18 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Set up mamba
+        uses: mamba-org/setup-micromamba@v1
         with:
-          miniforge-version: latest
-          miniforge-variant: mambaforge
-          channel-priority: strict
-          channels: conda-forge
-          show-channel-urls: true
-          use-only-tar-bz2: true
+          environment-file: environment-ci.yml
+          generate-run-shell: true
+          cache-environment: true
+          cache-downloads: true
 
-      - name: Install tobac and pylint
+      - name: Install tobac
         run: |
-          mamba install --yes pylint
           pip install .
 
       - name: Store the PR branch
@@ -37,7 +34,7 @@ jobs:
         id: git
 
       - name: Checkout RC branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
           
@@ -47,7 +44,7 @@ jobs:
         id: main_score
 
       - name: Checkout PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "${{ steps.git.outputs.SHA }}"  
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,7 +14,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Set up mamba
         uses: mamba-org/setup-micromamba@v1
@@ -34,7 +34,7 @@ jobs:
         id: git
 
       - name: Checkout RC branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.base_ref }}
           
@@ -44,7 +44,7 @@ jobs:
         id: main_score
 
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           ref: "${{ steps.git.outputs.SHA }}"  
 

--- a/environment-examples.yml
+++ b/environment-examples.yml
@@ -11,10 +11,18 @@ dependencies:
   - iris
   - xarray
   - cartopy
-  - trackpy
+  - trackpy>=0.6.1
   - pytest
   - typing_extensions
   - black
-  - coverage
-  - pytest-cov
-  - pylint
+  - jupyter
+  - notebook
+  - pytables
+  - s3fs
+  - arm_pyart
+  - seaborn
+  - h5netcdf
+  - typing_extensions
+  - rioxarray
+  - numba
+  - dask

--- a/environment-examples.yml
+++ b/environment-examples.yml
@@ -26,3 +26,4 @@ dependencies:
   - rioxarray
   - numba
   - dask
+  - ffmpeg

--- a/environment-examples.yml
+++ b/environment-examples.yml
@@ -9,7 +9,7 @@ dependencies:
   - pandas
   - matplotlib
   - iris
-  - xarray
+  - xarray<2024.10.0
   - cartopy
   - trackpy>=0.6.1
   - pytest


### PR DESCRIPTION
This continues the work from #457 and fixes issues with a few of our CI workflows that broke from `miniconda` being depreciated. 

Note that this is a _PR to main_ per our policy of CI improvements

* [ ] Have you followed our guidelines in CONTRIBUTING.md? 
* [ ] Have you self-reviewed your code and corrected any misspellings? 
* [ ] Have you written documentation that is easy to understand?
* [ ] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [ ] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [ ] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [ ] Have you kept your pull request small and limited so that it is easy to review? 
* [ ] Have the newest changes from this branch been merged? 

