### PR TITLE
Fix coordinate interpolation bug for non-numeric dtypes

### DIFF
--- a/tobac/tests/test_xarray_utils.py
+++ b/tobac/tests/test_xarray_utils.py
@@ -160,17 +160,26 @@ def test_find_axis_from_dim_coord(
         (
             ["time", "x", "y"],
             {
-                "test_coord_datetime": ("time", pd.date_range(
-                    datetime.datetime(2000,1,1), datetime.datetime(2000,1,1,6), freq="1h", inclusive="left", 
-                )),
+                "test_coord_datetime": (
+                    "time",
+                    pd.date_range(
+                        datetime.datetime(2000, 1, 1),
+                        datetime.datetime(2000, 1, 1, 6),
+                        freq="1h",
+                        inclusive="left",
+                    ),
+                ),
                 "test_coord_time": ("time", [5, 6, 7, 8, 9, 10]),
             },
             (1, 1),
             {
                 "test_coord_datetime": pd.date_range(
-                    datetime.datetime(2000,1,1), datetime.datetime(2000,1,1,3), freq="1h", inclusive="left", 
-                ), 
-                "test_coord_time": (5, 6, 7)
+                    datetime.datetime(2000, 1, 1),
+                    datetime.datetime(2000, 1, 1, 3),
+                    freq="1h",
+                    inclusive="left",
+                ),
+                "test_coord_time": (5, 6, 7),
             },
         ),
     ],
@@ -221,4 +230,3 @@ def test_add_coordinates_to_features_interpolate_along_other_dims(
         assert coord in resulting_df
         if coord != "time":
             assert np.all(resulting_df[coord].values == expected_vals[coord])
-

--- a/tobac/tests/test_xarray_utils.py
+++ b/tobac/tests/test_xarray_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Union
 
+import pandas as pd
 import pytest
 import numpy as np
 import xarray as xr
@@ -156,6 +157,22 @@ def test_find_axis_from_dim_coord(
             (1, 1),
             {"test_coord1": (1, 1, 1), "test_coord_time": (5, 6, 7)},
         ),
+        (
+            ["time", "x", "y"],
+            {
+                "test_coord_datetime": ("time", pd.date_range(
+                    datetime.datetime(2000,1,1), datetime.datetime(2000,1,1,6), freq="1h", inclusive="left", 
+                )),
+                "test_coord_time": ("time", [5, 6, 7, 8, 9, 10]),
+            },
+            (1, 1),
+            {
+                "test_coord_datetime": pd.date_range(
+                    datetime.datetime(2000,1,1), datetime.datetime(2000,1,1,3), freq="1h", inclusive="left", 
+                ), 
+                "test_coord_time": (5, 6, 7)
+            },
+        ),
     ],
 )
 def test_add_coordinates_to_features_interpolate_along_other_dims(
@@ -204,3 +221,4 @@ def test_add_coordinates_to_features_interpolate_along_other_dims(
         assert coord in resulting_df
         if coord != "time":
             assert np.all(resulting_df[coord].values == expected_vals[coord])
+

--- a/tobac/utils/internal/xarray_utils.py
+++ b/tobac/utils/internal/xarray_utils.py
@@ -420,7 +420,7 @@ def add_coordinates_to_features(
             except KeyError:
                 pass
 
-        try:
+        if renamed_dim_da[interp_coord].dtype.kind in "uifc":
             # Interpolate over the coordinate
             return_feat_df[interp_coord_name] = renamed_dim_da[interp_coord].interp(
                 coords={
@@ -428,7 +428,7 @@ def add_coordinates_to_features(
                     for dim in renamed_dim_da[interp_coord].dims
                 }
             )
-        except TypeError:
+        else:
             # If non-numeric, we should instead just index the nearest values:
             return_feat_df[interp_coord_name] = renamed_dim_da[interp_coord].isel(
                 **{

--- a/tobac/utils/internal/xarray_utils.py
+++ b/tobac/utils/internal/xarray_utils.py
@@ -420,9 +420,20 @@ def add_coordinates_to_features(
             except KeyError:
                 pass
 
-        return_feat_df[interp_coord_name] = renamed_dim_da[interp_coord].interp(
-            coords={
-                dim: dim_interp_coords[dim] for dim in renamed_dim_da[interp_coord].dims
-            }
-        )
+        try:
+            # Interpolate over the coordinate
+            return_feat_df[interp_coord_name] = renamed_dim_da[interp_coord].interp(
+                coords={
+                    dim: dim_interp_coords[dim]
+                    for dim in renamed_dim_da[interp_coord].dims
+                }
+            )
+        except TypeError:
+            # If non-numeric, we should instead just index the nearest values:
+            return_feat_df[interp_coord_name] = renamed_dim_da[interp_coord].isel(
+                **{
+                    dim: np.round(dim_interp_coords[dim]).astype(int)
+                    for dim in renamed_dim_da[interp_coord].dims
+                }
+            )
     return return_feat_df


### PR DESCRIPTION
Resolves the issue in #503 where feature detection would fail if there are non-numeric coordinates except for `time` (in that case, `step` and `valid_time` coordinates). This update checks for non-numeric coordinates and instead finds the nearest values rather than interpolating, in the same manner as done for time.

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [x] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [x] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [x] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

