### PR TITLE
Fix a conflict between the license file and the license string in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 description = "A package for identifying and tracking atmospheric phenomena"
 readme = "README.md"
 requires-python = ">=3.9,<3.14"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",


### PR DESCRIPTION
CI on conda-forge found this bug (https://github.com/conda-forge/tobac-feedstock/pull/41), I had to patch it in on the feedstock. Patching here upstream to resolve things. 

PR to main as it's an install issue. 

* [ ] Have you followed our guidelines in CONTRIBUTING.md? 
* [ ] Have you self-reviewed your code and corrected any misspellings? 
* [ ] Have you written documentation that is easy to understand?
* [ ] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [ ] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [ ] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [ ] Have you kept your pull request small and limited so that it is easy to review? 
* [ ] Have the newest changes from this branch been merged? 

