### PR TITLE
Return empty DataFrame when no features are detected

### DIFF
--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -1555,9 +1555,11 @@ def feature_detection_multithreshold(
                 label_fields[i].data[~wh_all_labels] = 0
 
     else:
-        features = None
-        label_fields = None
-        logging.debug("No features detected")
+        features = internal_utils.coordinates.make_empty_features_dataframe(is_3D=is_3D)
+        if return_labels:
+            # labels should be the initialised label_fields
+            pass
+        logging.debug("No features detected; returning empty features DataFrame")
 
     logging.debug("feature detection completed")
 

--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -1556,9 +1556,6 @@ def feature_detection_multithreshold(
 
     else:
         features = internal_utils.coordinates.make_empty_features_dataframe(is_3D=is_3D)
-        if return_labels:
-            # labels should be the initialised label_fields
-            pass
         logging.debug("No features detected; returning empty features DataFrame")
 
     logging.debug("feature detection completed")

--- a/tobac/segmentation/watershed_segmentation.py
+++ b/tobac/segmentation/watershed_segmentation.py
@@ -1258,6 +1258,12 @@ def segmentation(
         name="segmentation_mask",
     ).assign_attrs(threshold=threshold)
 
+    if features is None or features.empty:
+        logging.debug(
+            "No features provided; returning empty segmentation mask and empty features DataFrame"
+        )
+        return segmentation_out_data, features
+
     features_out_list = []
 
     if len(field.coords[time_var_name]) == 1:

--- a/tobac/tests/test_utils_internal.py
+++ b/tobac/tests/test_utils_internal.py
@@ -4,6 +4,7 @@ import tobac.testing as tbtest
 import pytest
 import numpy as np
 import xarray as xr
+import pandas.api.types as ptypes
 
 
 @pytest.mark.parametrize(
@@ -95,3 +96,90 @@ def test_detect_latlon_coord_name(
     )
     assert out_lat_name == expected_result[0]
     assert out_lon_name == expected_result[1]
+
+
+def test_make_empty_features_dataframe_2d():
+    """
+    Test that the empty 2D feature DataFrame has the correct columns and dtypes.
+    """
+    df = internal_utils.make_empty_features_dataframe(is_3D=False)
+
+    expected_cols = [
+        "frame",
+        "idx",
+        "hdim_1",
+        "hdim_2",
+        "num",
+        "threshold_value",
+        "feature",
+        "time",
+        "timestr",
+        "y",
+        "x",
+        "latitude",
+        "longitude",
+    ]
+
+    assert list(df.columns) == expected_cols
+    assert df.empty
+
+    assert ptypes.is_integer_dtype(df["frame"].dtype)
+    assert ptypes.is_integer_dtype(df["idx"].dtype)
+    assert ptypes.is_float_dtype(df["hdim_1"].dtype)
+    assert ptypes.is_float_dtype(df["hdim_2"].dtype)
+    assert ptypes.is_integer_dtype(df["num"].dtype)
+    assert ptypes.is_integer_dtype(df["threshold_value"].dtype)
+    assert ptypes.is_integer_dtype(df["feature"].dtype)
+
+    assert ptypes.is_datetime64_ns_dtype(df["time"].dtype)
+    assert df["timestr"].dtype == object
+
+    assert ptypes.is_float_dtype(df["y"].dtype)
+    assert ptypes.is_float_dtype(df["x"].dtype)
+    assert ptypes.is_float_dtype(df["latitude"].dtype)
+    assert ptypes.is_float_dtype(df["longitude"].dtype)
+
+
+def test_make_empty_features_dataframe_3d_schema_and_dtypes():
+    """
+    Test that the empty 3D feature DataFrame has the correct columns and dtypes.
+    """
+    df = internal_utils.make_empty_features_dataframe(is_3D=True)
+
+    expected_cols = [
+        "frame",
+        "idx",
+        "vdim",
+        "hdim_1",
+        "hdim_2",
+        "num",
+        "threshold_value",
+        "feature",
+        "time",
+        "timestr",
+        "z",
+        "y",
+        "x",
+        "latitude",
+        "longitude",
+    ]
+    assert list(df.columns) == expected_cols
+    assert df.empty
+
+    assert ptypes.is_integer_dtype(df["frame"].dtype)
+    assert ptypes.is_integer_dtype(df["idx"].dtype)
+    assert ptypes.is_float_dtype(df["vdim"].dtype)
+    assert ptypes.is_float_dtype(df["hdim_1"].dtype)
+    assert ptypes.is_float_dtype(df["hdim_2"].dtype)
+    assert ptypes.is_integer_dtype(df["num"].dtype)
+    assert ptypes.is_integer_dtype(df["threshold_value"].dtype)
+    assert ptypes.is_integer_dtype(df["feature"].dtype)
+
+    assert ptypes.is_datetime64_ns_dtype(df["time"].dtype)
+    assert df["timestr"].dtype == object
+
+    assert ptypes.is_float_dtype(df["z"].dtype)
+    assert ptypes.is_float_dtype(df["y"].dtype)
+    assert ptypes.is_float_dtype(df["x"].dtype)
+    assert ptypes.is_float_dtype(df["latitude"].dtype)
+    assert ptypes.is_float_dtype(df["longitude"].dtype)

--- a/tobac/utils/internal/coordinates.py
+++ b/tobac/utils/internal/coordinates.py
@@ -428,3 +428,59 @@ def detect_latlon_coord_name(
                 out_lon = test_lon_name
                 break
     return out_lat, out_lon
+
+
+def make_empty_features_dataframe(is_3D: bool) -> pd.DataFrame:
+    """
+    Create an empty but properly formatted feature DataFrame.
+
+    Returns an empty pandas DataFrame with the same columns and dtypes as the feature detection output.
+    This is used when no features are detected, to ensure a consistent return type and avoid returning ``None``.
+
+    Parameters
+    ----------
+    is_3d : bool
+        Whether the feature detection is 3D. If True, include vertical coordinate columns.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Empty DataFrame with the correct columns and dtypes for feature output.
+    """
+
+    if is_3D:
+        schema = {
+            "frame": "int64",
+            "idx": "int64",
+            "vdim": "float64",
+            "hdim_1": "float64",
+            "hdim_2": "float64",
+            "num": "int64",
+            "threshold_value": "int64",
+            "feature": "int64",
+            "time": "datetime64[ns]",
+            "timestr": "object",
+            "z": "float64",
+            "y": "float64",
+            "x": "float64",
+            "latitude": "float64",
+            "longitude": "float64",
+        }
+    else:
+        schema = {
+            "frame": "int64",
+            "idx": "int64",
+            "hdim_1": "float64",
+            "hdim_2": "float64",
+            "num": "int64",
+            "threshold_value": "int64",
+            "feature": "int64",
+            "time": "datetime64[ns]",
+            "timestr": "object",
+            "y": "float64",
+            "x": "float64",
+            "latitude": "float64",
+            "longitude": "float64",
+        }
+
+    return pd.DataFrame({c: pd.Series(dtype=t) for c, t in schema.items()})


### PR DESCRIPTION
Fixes #510 .

When no features are detected, return an empty but properly formatted DataFrame instead of None.
Adds tests for 2D and 3D feature detection and internal utilities.
