### PR TITLE
Pin pandas to versions 1 or 2 until Pandas 3 compatibility is added

### DIFF
--- a/environment-ci.yml
+++ b/environment-ci.yml
@@ -7,7 +7,7 @@ dependencies:
   - scipy
   - scikit-image
   - scikit-learn
-  - pandas
+  - pandas<3
   - matplotlib
   - iris
   - xarray

--- a/environment-examples.yml
+++ b/environment-examples.yml
@@ -6,7 +6,7 @@ dependencies:
   - scipy
   - scikit-image
   - scikit-learn
-  - pandas
+  - pandas<3
   - matplotlib
   - iris
   - xarray<2024.10.0

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - scipy
   - scikit-image
   - scikit-learn
-  - pandas
+  - pandas<3
   - matplotlib
   - iris
   - xarray

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "scipy",
     "scikit-image",
     "scikit-learn",
-    "pandas",
+    "pandas<3",
     "matplotlib",
     "scitools-iris",
     "xarray",

--- a/tobac/__init__.py
+++ b/tobac/__init__.py
@@ -6,9 +6,7 @@ if sys.version_info < (3, 7):
     Support for Python versions less than 3.7 is deprecated. 
     Version 1.5 of tobac will require Python 3.7 or later.
    Python {py} detected. \n\n
-    """.format(
-        py=".".join(str(v) for v in sys.version_info[:3])
-    )
+    """.format(py=".".join(str(v) for v in sys.version_info[:3]))
 
     print(warning)
 


### PR DESCRIPTION
Resolves #553 and pins pandas <3 for now. We will have to do a good amount of work to get ourselves compatible with Pandas 3. 

Given that this is currently a breaking issue, suggest that we release this with v1.6.3 as a hotfix ASAP. 

* [ ] Have you followed our guidelines in CONTRIBUTING.md? 
* [ ] Have you self-reviewed your code and corrected any misspellings? 
* [ ] Have you written documentation that is easy to understand?
* [ ] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [ ] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [ ] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [ ] Have you kept your pull request small and limited so that it is easy to review? 
* [ ] Have the newest changes from this branch been merged? 

