### PR TITLE
Add color parameter to map_tracks() function in plotting.py

### DIFF
--- a/tobac/plotting.py
+++ b/tobac/plotting.py
@@ -2018,7 +2018,7 @@ def plot_mask_cell_track_static_timeseries(
 
 
 def map_tracks(
-    track, axis_extent=None, figsize=None, axes=None, untracked_cell_value=-1
+    track, axis_extent=None, figsize=None, axes=None, untracked_cell_value=-1, color=""
 ):
     """Plot the trajectories of the cells on a map.
 
@@ -2044,6 +2044,10 @@ def map_tracks(
     untracked_cell_value : int or np.nan, optional
         Value of untracked cells in track['cell'].
         Default is -1.
+
+    color : str, optional
+        Color of all lines. Default is "", which MatPlotLib
+        defaults as the T10 color cycle.
 
     Returns
     -------
@@ -2072,7 +2076,7 @@ def map_tracks(
         if cell == untracked_cell_value:
             continue
         track_i = track[track["cell"] == cell]
-        axes.plot(track_i[lon_dim], track_i[lat_dim], "-")
+        axes.plot(track_i[lon_dim], track_i[lat_dim], color + "-")
         if axis_extent:
             axes.set_extent(axis_extent)
         axes = make_map(axes)


### PR DESCRIPTION
Sorry, this is a duplicate of a previous pull request (#563 ) that I accidentally closed when I deleted a repository. It adds a color parameter to the map_tracks() function in plotting.py. Here is the docstring for your convenience:

> color : str, optional
>         Color of all lines. Default is "", which MatPlotLib
>         defaults as the T10 color cycle.

* [x] Have you followed our guidelines in CONTRIBUTING.md? 
* [x] Have you self-reviewed your code and corrected any misspellings? 
* [x] Have you written documentation that is easy to understand?
* [x] Have you written descriptive commit messages? 
* [x] Have you added NumPy docstrings for newly added functions? 
* [x] Have you formatted your code using black? 
* [x] If you have introduced a new functionality, have you added adequate unit tests?
* [x] Have all tests passed in your local clone? 
* [x] If you have introduced a new functionality, have you added an example notebook?
* [x] Have you kept your pull request small and limited so that it is easy to review? 
* [x] Have the newest changes from this branch been merged? 

