### PR TITLE
Fix segmentation time pad test

### DIFF
--- a/tobac/tests/segmentation_tests/test_segmentation_time_pad.py
+++ b/tobac/tests/segmentation_tests/test_segmentation_time_pad.py
@@ -74,7 +74,6 @@ def test_watershed_segmentation_time_pad(
     # detect both features
     fd_output = feature_detection.feature_detection_multithreshold(
         test_data_xarray,
-        i_time=0,
         dxy=1,
         threshold=[1, 2, 3],
         n_min_threshold=test_min_num,


### PR DESCRIPTION
Resolves #565 by removing the `i_time` line (which does not belong) from the feature detection call. 

* [ ] Have you followed our guidelines in CONTRIBUTING.md? 
* [ ] Have you self-reviewed your code and corrected any misspellings? 
* [ ] Have you written documentation that is easy to understand?
* [ ] Have you written descriptive commit messages? 
* [ ] Have you added NumPy docstrings for newly added functions? 
* [ ] Have you formatted your code using black? 
* [ ] If you have introduced a new functionality, have you added adequate unit tests?
* [ ] Have all tests passed in your local clone? 
* [ ] If you have introduced a new functionality, have you added an example notebook?
* [ ] Have you kept your pull request small and limited so that it is easy to review? 
* [ ] Have the newest changes from this branch been merged? 

